### PR TITLE
Fix(unittest_json): Change order of JSON keys

### DIFF
--- a/src/unittest_json.nim
+++ b/src/unittest_json.nim
@@ -10,20 +10,20 @@ type
 
   JsonTestResult = object
     name: string
-    output: string
     case status: JsonTestStatus
     of FAIL, ERROR:
       message: string
     of PASS:
       discard
+    output: string
 
   ResultJson = ref object
-    tests: seq[JsonTestResult]
     case status: JsonTestStatus
     of ERROR:
       message: string
     of PASS, FAIL:
       discard
+    tests: seq[JsonTestResult]
 
   JsonOutputFormatter = ref object of OutputFormatter
     stream: Stream


### PR DESCRIPTION
This PR changes the JSON generated by `unittest_json.nim` to conform slightly better with [the spec](https://github.com/exercism/automated-tests/blob/master/docs/interface.md).

Consider an example: a single-test test file that fails. This PR causes the following `diff`:

```diff
{
+  "status": "fail",
   "tests": [
     {
       "name": "two() returns 2",
-      "output": "",
       "status": "fail",
-      "message": "/some/path/some_file.nim(8, 18): Check failed: two() == 2\\ntwo() was 0"
+      "message": "/some/path/some_file.nim(8, 18): Check failed: two() == 2\\ntwo() was 0",
+      "output": ""
     }
-  ],
+  ]
-  "status": "fail"
 }
```

See the commit message for more details.