### PR TITLE
Refactor(runner): Reduce verbosity

### DIFF
--- a/src/runner.nim
+++ b/src/runner.nim
@@ -102,7 +102,8 @@ proc run*(testPath: string): int =
   # Use `startProcess` here, not `execCmd`.
   result = -1
 
-  let args = @["c", "-r", "--styleCheck:hint", "--skipUserCfg:on", testPath]
+  let args = @["c", "-r", "--styleCheck:hint", "--skipUserCfg:on",
+               "--verbosity:0", "--hint[Processing]:off", testPath]
 
   var
     p = startProcess("nim", args = args, options = {poStdErrToStdOut, poUsePath})


### PR DESCRIPTION
This improves the readability of (especially) the `run all` suite's output, and also improves readability with the upcoming tests.