### PR TITLE
Fix(runner): Fix importing of `unittest_json`

### DIFF
--- a/src/runner.nim
+++ b/src/runner.nim
@@ -95,6 +95,8 @@ addOutputFormatter(formatter)
     editedTestContents &= line & '\n'
   editedTestContents &= afterTests
   writeFile(result, editedTestContents)
+  copyFile(getAppDir().parentDir() / "src" / "unittest_json.nim",
+           tmpDir / "unittest_json.nim")
   createDir(conf.outputDir)
 
 proc run*(testPath: string): int =

--- a/tests/trunner.nim
+++ b/tests/trunner.nim
@@ -36,9 +36,6 @@ for status in ["pass", "fail", "error"]:
                 outputDir / "results.json")
               check readFile(testPath) == expectedHelloWorldTest
 
-          copyFile(getAppDir().parentDir / "src" / "unittest_json.nim",
-                   tmpDir / "unittest_json.nim")
-
           let expectedExitCodeOfRunProc = if status == "pass": 0 else: 1
           test "The `run` proc returns the expected exit code":
             check run(testPath) == expectedExitCodeOfRunProc

--- a/tests/trunner_repo_solutions.nim
+++ b/tests/trunner_repo_solutions.nim
@@ -36,8 +36,6 @@ suite "repo solutions":
 
       let tmpDir = createTmpDir()
       let testPath = prepareFiles(conf, tmpDir)
-      copyFile(getAppDir().parentDir / "src" / "unittest_json.nim",
-               tmpDir / "unittest_json.nim")
       discard run(testPath)
       let resultsPath = conf.outputDir / "results.json"
       let j = parseFile(resultsPath)


### PR DESCRIPTION
We made a processed exercise test file able to import `unittest_json` simply by copying `unittest_json.nim` to the temporary directory. However, we did this copying only when running the existing tests, and not when executing the `runner` binary.

Therefore this commit moves the copying of `unittest_json.nim` into `runner.nim`.

I have an upcoming PR that adds tests for the `runner` binary.