### PR TITLE
Refactor(trunner): Add final newline in `writeJson`

### DIFF
--- a/tests/trunner.nim
+++ b/tests/trunner.nim
@@ -53,7 +53,7 @@ for status in ["pass", "fail", "error"]:
                 fail()
             else:
               when defined(writeJson):
-                writeFile(pathExpectedResultsJson, resultsJson.pretty())
+                writeFile(pathExpectedResultsJson, resultsJson.pretty() & '\n')
                 echo "Wrote: " & pathExpectedResultsJson
               else:
                 echo "Missing: " & pathExpectedResultsJson


### PR DESCRIPTION
Let's use this convention:
- The runner outputs `results.json` with zero newlines.
- The `expected_results.json` is in `pretty` format (which is more readable for maintainers), and has a final newline.

`tests/trunner.nim` has the ability to write `expected_results.json`, which is useful during development when adding new test cases. This PR makes that written file comply with the second rule above.