### PR TITLE
Test: Add simple `pass` and `fail` test cases

### DIFF
--- a/tests/fail/multiple_tests_all_fail/expected_results.json
+++ b/tests/fail/multiple_tests_all_fail/expected_results.json
@@ -1,0 +1,23 @@
+{
+  "status": "fail",
+  "tests": [
+    {
+      "name": "identity function of 1",
+      "status": "fail",
+      "message": "/tmp/nim_test_runner/identity_test.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
+      "output": ""
+    },
+    {
+      "name": "identity function of 2",
+      "status": "fail",
+      "message": "/tmp/nim_test_runner/identity_test.nim(14, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",
+      "output": ""
+    },
+    {
+      "name": "identity function of 3",
+      "status": "fail",
+      "message": "/tmp/nim_test_runner/identity_test.nim(17, 22): Check failed: identity(3) == 3000\\nidentity(3) was 3",
+      "output": ""
+    }
+  ]
+}

--- a/tests/fail/multiple_tests_all_fail/identity.nim
+++ b/tests/fail/multiple_tests_all_fail/identity.nim
@@ -1,0 +1,2 @@
+func identity*(n: int): int =
+  n

--- a/tests/fail/multiple_tests_all_fail/identity_test.nim
+++ b/tests/fail/multiple_tests_all_fail/identity_test.nim
@@ -1,0 +1,12 @@
+import unittest
+import identity
+
+suite "Identity Function":
+  test "identity function of 1":
+    check identity(1) == 1000
+
+  test "identity function of 2":
+    check identity(2) == 2000
+
+  test "identity function of 3":
+    check identity(3) == 3000

--- a/tests/fail/multiple_tests_multiple_fails/expected_results.json
+++ b/tests/fail/multiple_tests_multiple_fails/expected_results.json
@@ -1,0 +1,22 @@
+{
+  "status": "fail",
+  "tests": [
+    {
+      "name": "identity function of 1",
+      "status": "fail",
+      "message": "/tmp/nim_test_runner/identity_test.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
+      "output": ""
+    },
+    {
+      "name": "identity function of 2",
+      "status": "fail",
+      "message": "/tmp/nim_test_runner/identity_test.nim(14, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",
+      "output": ""
+    },
+    {
+      "name": "identity function of 3",
+      "status": "pass",
+      "output": ""
+    }
+  ]
+}

--- a/tests/fail/multiple_tests_multiple_fails/identity.nim
+++ b/tests/fail/multiple_tests_multiple_fails/identity.nim
@@ -1,0 +1,2 @@
+func identity*(n: int): int =
+  n

--- a/tests/fail/multiple_tests_multiple_fails/identity_test.nim
+++ b/tests/fail/multiple_tests_multiple_fails/identity_test.nim
@@ -1,0 +1,12 @@
+import unittest
+import identity
+
+suite "Identity Function":
+  test "identity function of 1":
+    check identity(1) == 1000
+
+  test "identity function of 2":
+    check identity(2) == 2000
+
+  test "identity function of 3":
+    check identity(3) == 3

--- a/tests/fail/multiple_tests_one_fail_first/expected_results.json
+++ b/tests/fail/multiple_tests_one_fail_first/expected_results.json
@@ -1,0 +1,21 @@
+{
+  "status": "fail",
+  "tests": [
+    {
+      "name": "identity function of 1",
+      "status": "fail",
+      "message": "/tmp/nim_test_runner/identity_test.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
+      "output": ""
+    },
+    {
+      "name": "identity function of 2",
+      "status": "pass",
+      "output": ""
+    },
+    {
+      "name": "identity function of 3",
+      "status": "pass",
+      "output": ""
+    }
+  ]
+}

--- a/tests/fail/multiple_tests_one_fail_first/identity.nim
+++ b/tests/fail/multiple_tests_one_fail_first/identity.nim
@@ -1,0 +1,2 @@
+func identity*(n: int): int =
+  n

--- a/tests/fail/multiple_tests_one_fail_first/identity_test.nim
+++ b/tests/fail/multiple_tests_one_fail_first/identity_test.nim
@@ -1,0 +1,12 @@
+import unittest
+import identity
+
+suite "Identity Function":
+  test "identity function of 1":
+    check identity(1) == 1000
+
+  test "identity function of 2":
+    check identity(2) == 2
+
+  test "identity function of 3":
+    check identity(3) == 3

--- a/tests/fail/multiple_tests_one_fail_last/expected_results.json
+++ b/tests/fail/multiple_tests_one_fail_last/expected_results.json
@@ -1,0 +1,21 @@
+{
+  "status": "fail",
+  "tests": [
+    {
+      "name": "identity function of 1",
+      "status": "pass",
+      "output": ""
+    },
+    {
+      "name": "identity function of 2",
+      "status": "pass",
+      "output": ""
+    },
+    {
+      "name": "identity function of 3",
+      "status": "fail",
+      "message": "/tmp/nim_test_runner/identity_test.nim(17, 22): Check failed: identity(3) == 3000\\nidentity(3) was 3",
+      "output": ""
+    }
+  ]
+}

--- a/tests/fail/multiple_tests_one_fail_last/identity.nim
+++ b/tests/fail/multiple_tests_one_fail_last/identity.nim
@@ -1,0 +1,2 @@
+func identity*(n: int): int =
+  n

--- a/tests/fail/multiple_tests_one_fail_last/identity_test.nim
+++ b/tests/fail/multiple_tests_one_fail_last/identity_test.nim
@@ -1,0 +1,12 @@
+import unittest
+import identity
+
+suite "Identity Function":
+  test "identity function of 1":
+    check identity(1) == 1
+
+  test "identity function of 2":
+    check identity(2) == 2
+
+  test "identity function of 3":
+    check identity(3) == 3000

--- a/tests/fail/multiple_tests_one_fail_middle/expected_results.json
+++ b/tests/fail/multiple_tests_one_fail_middle/expected_results.json
@@ -1,0 +1,21 @@
+{
+  "status": "fail",
+  "tests": [
+    {
+      "name": "identity function of 1",
+      "status": "pass",
+      "output": ""
+    },
+    {
+      "name": "identity function of 2",
+      "status": "fail",
+      "message": "/tmp/nim_test_runner/identity_test.nim(14, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",
+      "output": ""
+    },
+    {
+      "name": "identity function of 3",
+      "status": "pass",
+      "output": ""
+    }
+  ]
+}

--- a/tests/fail/multiple_tests_one_fail_middle/identity.nim
+++ b/tests/fail/multiple_tests_one_fail_middle/identity.nim
@@ -1,0 +1,2 @@
+func identity*(n: int): int =
+  n

--- a/tests/fail/multiple_tests_one_fail_middle/identity_test.nim
+++ b/tests/fail/multiple_tests_one_fail_middle/identity_test.nim
@@ -1,0 +1,12 @@
+import unittest
+import identity
+
+suite "Identity Function":
+  test "identity function of 1":
+    check identity(1) == 1
+
+  test "identity function of 2":
+    check identity(2) == 2000
+
+  test "identity function of 3":
+    check identity(3) == 3

--- a/tests/fail/single_test/expected_results.json
+++ b/tests/fail/single_test/expected_results.json
@@ -1,0 +1,11 @@
+{
+  "status": "fail",
+  "tests": [
+    {
+      "name": "identity function of 1",
+      "status": "fail",
+      "message": "/tmp/nim_test_runner/identity_test.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
+      "output": ""
+    }
+  ]
+}

--- a/tests/fail/single_test/identity.nim
+++ b/tests/fail/single_test/identity.nim
@@ -1,0 +1,2 @@
+func identity*(n: int): int =
+  n

--- a/tests/fail/single_test/identity_test.nim
+++ b/tests/fail/single_test/identity_test.nim
@@ -1,0 +1,6 @@
+import unittest
+import identity
+
+suite "Identity Function":
+  test "identity function of 1":
+    check identity(1) == 1000

--- a/tests/pass/multiple_tests/expected_results.json
+++ b/tests/pass/multiple_tests/expected_results.json
@@ -1,0 +1,20 @@
+{
+  "status": "pass",
+  "tests": [
+    {
+      "name": "identity function of 1",
+      "status": "pass",
+      "output": ""
+    },
+    {
+      "name": "identity function of 2",
+      "status": "pass",
+      "output": ""
+    },
+    {
+      "name": "identity function of 3",
+      "status": "pass",
+      "output": ""
+    }
+  ]
+}

--- a/tests/pass/multiple_tests/identity.nim
+++ b/tests/pass/multiple_tests/identity.nim
@@ -1,0 +1,2 @@
+func identity*(n: int): int =
+  n

--- a/tests/pass/multiple_tests/identity_test.nim
+++ b/tests/pass/multiple_tests/identity_test.nim
@@ -1,0 +1,12 @@
+import unittest
+import identity
+
+suite "Identity Function":
+  test "identity function of 1":
+    check identity(1) == 1
+
+  test "identity function of 2":
+    check identity(2) == 2
+
+  test "identity function of 3":
+    check identity(3) == 3


### PR DESCRIPTION
This PR adds simple `pass` and `fail` cases where the `runner` works. It also documents the current flawed behavior with the content of `message` keys so that it's easier to improve in the future.

See the commit messages for more details.