### PR TITLE
Chore: Bump nim from 1.2.0 to 1.2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   job1:
     name: trunner.nim
     runs-on: ubuntu-18.04
-    container: nimlang/nim:1.2.0-ubuntu-regular@sha256:8b01cd35ed76c96a0a1e95113adf1a641c490a30918ea52aed4852830ad0939c
+    container: nimlang/nim:1.2.2-ubuntu-regular@sha256:3020d8eccf77e52a82a55c2eb746177aea1c2c9a252396a568a5264d81aa32b0
 
     steps:
     - uses: actions/checkout@aabbfeb2ce60b5bd82389903509092c4648a9713 # v2.2.0
@@ -30,7 +30,7 @@ jobs:
       run: git clone --depth 1 https://github.com/exercism/nim.git
 
     - name: Build image
-      run: docker build -t exercism/nim-test-runner:1.2.0 .
+      run: docker build -t exercism/nim-test-runner:1.2.2 .
 
     - name: Smoke test the image (using the `bin/run.sh` production interface)
       run: |
@@ -39,7 +39,7 @@ jobs:
         # `bin/run.sh` as used in production. Note that the arguments to
         # `bin/run.sh` must come after the image name.
         docker create --name ntr --entrypoint 'bin/run.sh' \
-          exercism/nim-test-runner:1.2.0 hello-world /tmp/ /tmp/out/
+          exercism/nim-test-runner:1.2.2 hello-world /tmp/ /tmp/out/
         # Copy an exercise solution and test file from the `exercism/nim` repo.
         docker cp nim/exercises/hello-world/hello_world_test.nim ntr:/tmp/
         docker cp nim/exercises/hello-world/example.nim ntr:/tmp/hello_world.nim
@@ -59,7 +59,7 @@ jobs:
       run: |
         # Create a container from the image we built, using the `ENTRYPOINT`
         # defined in the Dockerfile.
-        docker create --rm --name ntr exercism/nim-test-runner:1.2.0
+        docker create --rm --name ntr exercism/nim-test-runner:1.2.2
         # Copy the required files and run the tests.
         docker cp src/runner.nim ntr:/opt/test-runner/src/
         docker cp tests/ ntr:/opt/test-runner/tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM nimlang/nim:1.2.0-alpine-slim@sha256:8859f05f8d0a24a20c79362fd1c61f6d04111e4f7df472b2d9e55f3178b75b49 \
+FROM nimlang/nim:1.2.2-alpine-slim@sha256:1addf585b1f807991f375b4c9cc54df930b763af4155833087a8b84f7ac9c839 \
      AS builder
 COPY src/runner.nim /build/
 RUN nim c -d:release /build/runner.nim
 
-FROM nimlang/nim:1.2.0-alpine-slim@sha256:8859f05f8d0a24a20c79362fd1c61f6d04111e4f7df472b2d9e55f3178b75b49
+FROM nimlang/nim:1.2.2-alpine-slim@sha256:1addf585b1f807991f375b4c9cc54df930b763af4155833087a8b84f7ac9c839
 RUN apk add --no-cache pcre
 WORKDIR /opt/test-runner/
 COPY --from=builder /build/runner bin/


### PR DESCRIPTION
This PR updates our `Dockerfile` and CI workflow to use the latest stable Nim release.

See: https://nim-lang.org/blog/2020/06/17/version-122-released.html