### PR TITLE
Fix(unittest_json): Support test-level `error` status

### DIFF
--- a/src/unittest_json.nim
+++ b/src/unittest_json.nim
@@ -97,7 +97,7 @@ method testEnded(formatter: JsonOutputFormatter, testResult: TestResult) =
     if formatter.testStackTrace.len > 0:
       jsonTestResult = JsonTestResult(
         name: testResult.testName,
-        status: FAIL,
+        status: ERROR,
         message: fmt"{failureMsg}\n{formatter.testStackTrace}"
       )
       if errs.len > 0:

--- a/tests/error/runtime_exception_in_solution/expected_results.json
+++ b/tests/error/runtime_exception_in_solution/expected_results.json
@@ -1,0 +1,11 @@
+{
+  "status": "fail",
+  "tests": [
+    {
+      "name": "identity function of 1",
+      "status": "error",
+      "message": "Unhandled exception: myValueError [ValueError]\\n/nim/lib/pure/unittest.nim(647) identity_test\n/tmp/nim_test_runner/identity.nim(2) identity\n",
+      "output": ""
+    }
+  ]
+}

--- a/tests/error/runtime_exception_in_solution/identity.nim
+++ b/tests/error/runtime_exception_in_solution/identity.nim
@@ -1,0 +1,2 @@
+func identity*(n: int): int =
+  raise newException(ValueError, "myValueError")

--- a/tests/error/runtime_exception_in_solution/identity_test.nim
+++ b/tests/error/runtime_exception_in_solution/identity_test.nim
@@ -1,0 +1,6 @@
+import unittest
+import identity
+
+suite "Identity Function":
+  test "identity function of 1":
+    check identity(1) == 1


### PR DESCRIPTION
If the test file and the user's solution both compile successfully, a runtime problem like an uncaught exception should produce:
- a top-level `status` of `fail`.
- a test-level `status` of `error`.

However, in such cases our test-level `status` was `fail`. This PR changes it to `error`, and adds a test.

I think we can make the specification clearer on this point.

@iHiD quote from Slack:
> If the solution fails to compile or the tests can’t run for some reason, then the top level status should be `error`. If the tests can run, then the top level status should be `pass` or `fail`. So if a test runs but `error`s, that should result in the top level status being `fail`.

> To put it another way, in the UI, if we get a top level `error`, we’ll only show the top level message, not any of the test fails/errors.