### PR TITLE
Fix: Support top-level `error` status (and add tests)

### DIFF
--- a/src/runner.nim
+++ b/src/runner.nim
@@ -1,4 +1,4 @@
-import os, osproc, parseopt, streams, strutils, terminal
+import os, osproc, parseopt, strutils, terminal
 
 proc writeHelp =
   echo """Usage:
@@ -125,25 +125,10 @@ proc prepareFiles*(paths: Paths) =
 
 proc run*(paths: Paths): int =
   ## Compiles and runs the file in `testPath`. Returns its exit code.
-  # Use `startProcess` here, not `execCmd`.
-  result = -1
-
-  let args = @["c", "-r", "--styleCheck:hint", "--skipUserCfg:on",
-               "--verbosity:0", "--hint[Processing]:off", paths.tmpTest]
-
-  var
-    p = startProcess("nim", args = args, options = {poStdErrToStdOut, poUsePath})
-    outp = outputStream(p)
-    line = newStringOfCap(120).TaintedString
-
-  while true:
-    if outp.readLine(line):
-      stdout.writeLine(line)
-    else:
-      result = peekExitCode(p)
-      if result != -1:
-        break
-  close(p)
+  let (_, exitCode) = execCmdEx("nim c -r --styleCheck:hint --skipUserCfg:on " &
+                                "--verbosity:0 --hint[Processing]:off " &
+                                paths.tmpTest)
+  result = exitCode
 
 when isMainModule:
   let conf = parseCmdLine()

--- a/tests/error/compiletime_crash_in_solution/expected_results.json
+++ b/tests/error/compiletime_crash_in_solution/expected_results.json
@@ -1,0 +1,5 @@
+{
+  "status": "error",
+  "message": "Error: internal error: getTypeDescAux(tyEmpty)\nNo stack traceback available\nTo create a stacktrace, rerun compilation with ./koch temp c <file>\n",
+  "tests": []
+}

--- a/tests/error/compiletime_crash_in_solution/identity.nim
+++ b/tests/error/compiletime_crash_in_solution/identity.nim
@@ -1,0 +1,4 @@
+func identity*(n: int): int =
+  # Trigger a crash. See https://github.com/nim-lang/Nim/issues/11684
+  for _ in []:
+    discard

--- a/tests/error/compiletime_crash_in_solution/identity_test.nim
+++ b/tests/error/compiletime_crash_in_solution/identity_test.nim
@@ -1,0 +1,6 @@
+import unittest
+import identity
+
+suite "Identity Function":
+  test "identity function of 1":
+    check identity(1) == 1

--- a/tests/error/compiletime_error_empty_solution/expected_results.json
+++ b/tests/error/compiletime_error_empty_solution/expected_results.json
@@ -1,0 +1,5 @@
+{
+  "status": "error",
+  "message": "/tmp/nim_test_runner/identity_test.nim(9, 7) template/generic instantiation of `suite` from here\n/tmp/nim_test_runner/identity_test.nim(10, 8) template/generic instantiation of `test` from here\n/tmp/nim_test_runner/identity_test.nim(11, 11) Error: undeclared identifier: 'identity'\n",
+  "tests": []
+}

--- a/tests/error/compiletime_error_empty_solution/identity_test.nim
+++ b/tests/error/compiletime_error_empty_solution/identity_test.nim
@@ -1,0 +1,6 @@
+import unittest
+import identity
+
+suite "Identity Function":
+  test "identity function of 1":
+    check identity(1) == 1

--- a/tests/error/compiletime_error_type_mismatch_in_test/expected_results.json
+++ b/tests/error/compiletime_error_type_mismatch_in_test/expected_results.json
@@ -1,0 +1,5 @@
+{
+  "status": "error",
+  "message": "/tmp/nim_test_runner/identity_test.nim(9, 7) template/generic instantiation of `suite` from here\n/tmp/nim_test_runner/identity_test.nim(10, 8) template/generic instantiation of `test` from here\n/tmp/nim_test_runner/identity_test.nim(11, 11) template/generic instantiation of `check` from here\n/nim/lib/pure/unittest.nim(647, 43) Error: type mismatch: got <int literal(1)>\nbut expected one of: \nfunc identity(s: string): string\n  first type mismatch at position: 1\n  required type for s: string\n  but expression '1' is of type: int literal(1)\n\nexpression: identity(1)\n",
+  "tests": []
+}

--- a/tests/error/compiletime_error_type_mismatch_in_test/identity.nim
+++ b/tests/error/compiletime_error_type_mismatch_in_test/identity.nim
@@ -1,0 +1,2 @@
+func identity*(s: string): string =
+  s

--- a/tests/error/compiletime_error_type_mismatch_in_test/identity_test.nim
+++ b/tests/error/compiletime_error_type_mismatch_in_test/identity_test.nim
@@ -1,0 +1,6 @@
+import unittest
+import identity
+
+suite "Identity Function":
+  test "identity function of 1":
+    check identity(1) == 1

--- a/tests/error/compiletime_error_undeclared_variable_in_solution/expected_results.json
+++ b/tests/error/compiletime_error_undeclared_variable_in_solution/expected_results.json
@@ -1,0 +1,5 @@
+{
+  "status": "error",
+  "message": "/tmp/nim_test_runner/identity.nim(2, 3) Error: undeclared identifier: 'myUndeclaredVariable'\n",
+  "tests": []
+}

--- a/tests/error/compiletime_error_undeclared_variable_in_solution/identity.nim
+++ b/tests/error/compiletime_error_undeclared_variable_in_solution/identity.nim
@@ -1,0 +1,2 @@
+func identity*(n: int): int =
+  myUndeclaredVariable = 5

--- a/tests/error/compiletime_error_undeclared_variable_in_solution/identity_test.nim
+++ b/tests/error/compiletime_error_undeclared_variable_in_solution/identity_test.nim
@@ -1,0 +1,6 @@
+import unittest
+import identity
+
+suite "Identity Function":
+  test "identity function of 1":
+    check identity(1) == 1

--- a/tests/error/compiletime_exception_in_solution/expected_results.json
+++ b/tests/error/compiletime_exception_in_solution/expected_results.json
@@ -1,0 +1,5 @@
+{
+  "status": "error",
+  "message": "stack trace: (most recent call last)\n/tmp/nim_test_runner/identity.nim(3, 5) identity\n/tmp/nim_test_runner/identity.nim(3, 5) Error: unhandled exception: myValueError [ValueError]\n",
+  "tests": []
+}

--- a/tests/error/compiletime_exception_in_solution/identity.nim
+++ b/tests/error/compiletime_exception_in_solution/identity.nim
@@ -1,0 +1,3 @@
+func identity*(n: int): int =
+  static:
+    raise newException(ValueError, "myValueError")

--- a/tests/error/compiletime_exception_in_solution/identity_test.nim
+++ b/tests/error/compiletime_exception_in_solution/identity_test.nim
@@ -1,0 +1,6 @@
+import unittest
+import identity
+
+suite "Identity Function":
+  test "identity function of 1":
+    check identity(1) == 1

--- a/tests/trunner_repo_solutions.nim
+++ b/tests/trunner_repo_solutions.nim
@@ -35,11 +35,10 @@ proc repoSolutions* =
                         inputDir: slugDir,
                         outputDir: outputDir)
 
-        let tmpDir = createTmpDir()
-        let testPath = prepareFiles(conf, tmpDir)
-        discard run(testPath)
-        let resultsPath = conf.outputDir / "results.json"
-        let j = parseFile(resultsPath)
+        let paths = getPaths(conf)
+        prepareFiles(paths)
+        discard run(paths)
+        let j = parseFile(paths.outResults)
         for test in j["tests"]:
           check:
             test["name"].getStr().len > 0
@@ -48,7 +47,7 @@ proc repoSolutions* =
             test.len == 3
         check:
           j["status"].getStr() == "pass"
-        moveFile(resultsPath, conf.outputDir / slugUnder & ".json")
+        moveFile(paths.outResults, conf.outputDir / slugUnder & ".json")
 
 when isMainModule:
   repoSolutions()


### PR DESCRIPTION
This PR:
- Improves the clarity of the path handling code in `runner.nim`.
- Fixes the runner so that a compile error produces `results.json` with a top-level `error` status. 
- Adds test cases for top-level `error` status.

See the commit messags for more details.