### PR TITLE
Fix(runner): escape compilation quotes in messages 

### DIFF
--- a/src/runner.nim
+++ b/src/runner.nim
@@ -1,4 +1,4 @@
-import os, osproc, parseopt, strutils, terminal
+import json, os, osproc, parseopt, strutils, terminal
 
 proc writeHelp =
   echo """Usage:
@@ -97,8 +97,8 @@ proc getPaths*(conf: Conf): Paths =
 proc writeTopLevelErrorJson(path: string, message: string) =
   ## Writes to `path` a JSON file that has a top-level error status, and a
   ## top-level message of `message`.
-  let contents = """{"status": "error", "message": """" & message &
-                 """", "tests": []}"""
+  let contents = """{"status": "error", "message": """ & message.escapeJson() &
+                 """, "tests": []}"""
   writeFile(path, contents)
 
 proc copyEditedTest(paths: Paths) =

--- a/tests/error/compiletime_error_closing_quote_expected/expected_results.json
+++ b/tests/error/compiletime_error_closing_quote_expected/expected_results.json
@@ -1,0 +1,5 @@
+{
+  "status": "error",
+  "message": "/tmp/nim_test_runner/hello_world.nim(2, 3) Error: closing \" expected\n",
+  "tests": []
+}

--- a/tests/error/compiletime_error_closing_quote_expected/hello_world.nim
+++ b/tests/error/compiletime_error_closing_quote_expected/hello_world.nim
@@ -1,3 +1,2 @@
 func hello*: string =
   "Hello, World!
-

--- a/tests/error/compiletime_error_closing_quote_expected/hello_world.nim
+++ b/tests/error/compiletime_error_closing_quote_expected/hello_world.nim
@@ -1,0 +1,3 @@
+func hello*: string =
+  "Hello, World!
+

--- a/tests/error/compiletime_error_closing_quote_expected/hello_world_test.nim
+++ b/tests/error/compiletime_error_closing_quote_expected/hello_world_test.nim
@@ -1,0 +1,8 @@
+import unittest
+import hello_world
+
+# version 1.1.0
+
+suite "Hello World":
+  test "say hi":
+    check hello() == "Hello, World!"


### PR DESCRIPTION
The `results.json` files with compilation errors were being written directly without using the `json` package, and therefore if the string had double-quotes in the messages, it wouldn't be able to be parsed. 
This is demonstrated [here](https://github.com/exercism/nim-test-runner/runs/867853937) by having a test case where the compilation error message has a double-quote in the message and the parser fails.
The aforementioned submission file is 
```nim
func hello*: string =
  "Hello, World!
```
and the test file is
```nim
import unittest
import hello_world

# version 1.1.0

suite "Hello World":
  test "say hi":
    check hello() == "Hello, World!"
```