### PR TITLE
Chore: Bump nim from 1.2.4 to 1.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   job1:
     name: trunner.nim
     runs-on: ubuntu-18.04
-    container: nimlang/nim:1.2.4-ubuntu-regular@sha256:02a555518a05c354ccb2627940f6138fca1090d198e5a0eb60936c03a4875c69
+    container: nimlang/nim:1.4.0-ubuntu-regular@sha256:bf508ba3ba8d3407e52b4dfeaea0748e41cd28bec9a91d1f78b0d43e00cd639a
 
     steps:
     - uses: actions/checkout@aabbfeb2ce60b5bd82389903509092c4648a9713 # v2.2.0
@@ -30,7 +30,7 @@ jobs:
       run: git clone --depth 1 https://github.com/exercism/nim.git
 
     - name: Build image
-      run: docker build -t exercism/nim-test-runner:1.2.4 .
+      run: docker build -t exercism/nim-test-runner:1.4.0 .
 
     - name: Smoke test the image (using the `bin/run.sh` production interface)
       run: |
@@ -39,7 +39,7 @@ jobs:
         # `bin/run.sh` as used in production. Note that the arguments to
         # `bin/run.sh` must come after the image name.
         docker create --name ntr --entrypoint 'bin/run.sh' \
-          exercism/nim-test-runner:1.2.4 hello-world /tmp/ /tmp/out/
+          exercism/nim-test-runner:1.4.0 hello-world /tmp/ /tmp/out/
         # Copy an exercise solution and test file from the `exercism/nim` repo.
         docker cp nim/exercises/hello-world/hello_world_test.nim ntr:/tmp/
         docker cp nim/exercises/hello-world/example.nim ntr:/tmp/hello_world.nim
@@ -59,7 +59,7 @@ jobs:
       run: |
         # Create a container from the image we built, using the `ENTRYPOINT`
         # defined in the Dockerfile.
-        docker create --rm --name ntr exercism/nim-test-runner:1.2.4
+        docker create --rm --name ntr exercism/nim-test-runner:1.4.0
         # Copy the required files and run the tests.
         docker cp src/runner.nim ntr:/opt/test-runner/src/
         docker cp tests/ ntr:/opt/test-runner/tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM nimlang/nim:1.2.4-alpine-slim@sha256:9afaf7c89c44e5200620e3697e15330de32dbc7ac0fd3f0c99ed13cf185b9c30 \
+FROM nimlang/nim:1.4.0-alpine-slim@sha256:36c84bab9f2020e462604fff06860bebd95310ea065d35d4cc8c755ea30694ae \
      AS builder
 COPY src/runner.nim /build/
 RUN nim c -d:release /build/runner.nim
 
-FROM nimlang/nim:1.2.4-alpine-slim@sha256:9afaf7c89c44e5200620e3697e15330de32dbc7ac0fd3f0c99ed13cf185b9c30
+FROM nimlang/nim:1.4.0-alpine-slim@sha256:36c84bab9f2020e462604fff06860bebd95310ea065d35d4cc8c755ea30694ae
 RUN apk add --no-cache pcre
 WORKDIR /opt/test-runner/
 COPY --from=builder /build/runner bin/

--- a/tests/error/compiletime_crash_in_solution/expected_results.json
+++ b/tests/error/compiletime_crash_in_solution/expected_results.json
@@ -1,5 +1,5 @@
 {
   "status": "error",
-  "message": "Error: internal error: getTypeDescAux(tyEmpty)\nNo stack traceback available\nTo create a stacktrace, rerun compilation with ./koch temp c <file>\n",
+  "message": "Error: internal error: getTypeDescAux(tyEmpty)\nNo stack traceback available\nTo create a stacktrace, rerun compilation with './koch temp c <file>', see https://nim-lang.github.io/Nim/intern.html#debugging-the-compiler for details\n",
   "tests": []
 }

--- a/tests/error/compiletime_error_type_mismatch_in_test/expected_results.json
+++ b/tests/error/compiletime_error_type_mismatch_in_test/expected_results.json
@@ -1,5 +1,5 @@
 {
   "status": "error",
-  "message": "/tmp/nim_test_runner/identity_test.nim(9, 7) template/generic instantiation of `suite` from here\n/tmp/nim_test_runner/identity_test.nim(10, 8) template/generic instantiation of `test` from here\n/tmp/nim_test_runner/identity_test.nim(11, 11) template/generic instantiation of `check` from here\n/nim/lib/pure/unittest.nim(647, 43) Error: type mismatch: got <int literal(1)>\nbut expected one of: \nfunc identity(s: string): string\n  first type mismatch at position: 1\n  required type for s: string\n  but expression '1' is of type: int literal(1)\n\nexpression: identity(1)\n",
+  "message": "/tmp/nim_test_runner/identity_test.nim(9, 7) template/generic instantiation of `suite` from here\n/tmp/nim_test_runner/identity_test.nim(10, 8) template/generic instantiation of `test` from here\n/tmp/nim_test_runner/identity_test.nim(11, 11) template/generic instantiation of `check` from here\n/nim/lib/pure/unittest.nim(646, 43) Error: type mismatch: got <int literal(1)>\nbut expected one of: \nfunc identity(s: string): string\n  first type mismatch at position: 1\n  required type for s: string\n  but expression '1' is of type: int literal(1)\n\nexpression: identity(1)\n",
   "tests": []
 }

--- a/tests/error/runtime_exception_in_solution/expected_results.json
+++ b/tests/error/runtime_exception_in_solution/expected_results.json
@@ -4,7 +4,7 @@
     {
       "name": "identity function of 1",
       "status": "error",
-      "message": "Unhandled exception: myValueError [ValueError]\\n/nim/lib/pure/unittest.nim(647) identity_test\n/tmp/nim_test_runner/identity.nim(2) identity\n",
+      "message": "Unhandled exception: myValueError [ValueError]\\n/nim/lib/pure/unittest.nim(646) identity_test\n/tmp/nim_test_runner/identity.nim(2) identity\n",
       "output": ""
     }
   ]


### PR DESCRIPTION
This PR updates our `Dockerfile` and CI workflow to use the latest stable Nim release.

We skipped Nim 1.2.6.

See:
- https://nim-lang.org/blog/2020/07/30/versions-126-and-108-released.html
- https://nim-lang.org/blog/2020/10/16/version-140-released.html

### WIP: 
- [x] Update with the new hashes when the 1.4.0 Docker images become available.
- [X] Update the tests to have the error messages that occur with Nim 1.4.0.
- [x] Merge https://github.com/exercism/nim-test-runner/pull/29 then rebase this PR on `master`.
- [x] Get an approving review from @exercism/ops (which is required, as this PR changes the `Dockerfile`).
- [x] Get an approving review from a reviewer with write access.