### PR TITLE
Refactor: Rename test files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         docker create --name ntr --entrypoint 'bin/run.sh' \
           exercism/nim-test-runner:1.4.0 hello-world /tmp/ /tmp/out/
         # Copy an exercise solution and test file from the `exercism/nim` repo.
-        docker cp nim/exercises/hello-world/hello_world_test.nim ntr:/tmp/
+        docker cp nim/exercises/hello-world/test_hello_world.nim ntr:/tmp/
         docker cp nim/exercises/hello-world/example.nim ntr:/tmp/hello_world.nim
         # Start the container. The runner runs the `hello-world` test.
         docker start -a ntr

--- a/src/runner.nim
+++ b/src/runner.nim
@@ -81,8 +81,8 @@ type
 proc getPaths*(conf: Conf): Paths =
   let
     slugUnder = conf.slug.replace("-", "_")
-    solName = slugUnder & ".nim"       # e.g. "hello_world.nim"
-    testName = slugUnder & "_test.nim" # e.g. "hello_world_test.nim"
+    solName = slugUnder & ".nim"            # e.g. "hello_world.nim"
+    testName = "test_" & slugUnder & ".nim" # e.g. "test_hello_world.nim"
     tmpDir = createTmpDir()
   result = Paths(
     inputSol: conf.inputDir / solName,

--- a/tests/error/compiletime_error_empty_solution/expected_results.json
+++ b/tests/error/compiletime_error_empty_solution/expected_results.json
@@ -1,5 +1,5 @@
 {
   "status": "error",
-  "message": "/tmp/nim_test_runner/identity_test.nim(9, 7) template/generic instantiation of `suite` from here\n/tmp/nim_test_runner/identity_test.nim(10, 8) template/generic instantiation of `test` from here\n/tmp/nim_test_runner/identity_test.nim(11, 11) Error: undeclared identifier: 'identity'\n",
+  "message": "/tmp/nim_test_runner/test_identity.nim(9, 7) template/generic instantiation of `suite` from here\n/tmp/nim_test_runner/test_identity.nim(10, 8) template/generic instantiation of `test` from here\n/tmp/nim_test_runner/test_identity.nim(11, 11) Error: undeclared identifier: 'identity'\n",
   "tests": []
 }

--- a/tests/error/compiletime_error_type_mismatch_in_test/expected_results.json
+++ b/tests/error/compiletime_error_type_mismatch_in_test/expected_results.json
@@ -1,5 +1,5 @@
 {
   "status": "error",
-  "message": "/tmp/nim_test_runner/identity_test.nim(9, 7) template/generic instantiation of `suite` from here\n/tmp/nim_test_runner/identity_test.nim(10, 8) template/generic instantiation of `test` from here\n/tmp/nim_test_runner/identity_test.nim(11, 11) template/generic instantiation of `check` from here\n/nim/lib/pure/unittest.nim(646, 43) Error: type mismatch: got <int literal(1)>\nbut expected one of: \nfunc identity(s: string): string\n  first type mismatch at position: 1\n  required type for s: string\n  but expression '1' is of type: int literal(1)\n\nexpression: identity(1)\n",
+  "message": "/tmp/nim_test_runner/test_identity.nim(9, 7) template/generic instantiation of `suite` from here\n/tmp/nim_test_runner/test_identity.nim(10, 8) template/generic instantiation of `test` from here\n/tmp/nim_test_runner/test_identity.nim(11, 11) template/generic instantiation of `check` from here\n/nim/lib/pure/unittest.nim(646, 43) Error: type mismatch: got <int literal(1)>\nbut expected one of: \nfunc identity(s: string): string\n  first type mismatch at position: 1\n  required type for s: string\n  but expression '1' is of type: int literal(1)\n\nexpression: identity(1)\n",
   "tests": []
 }

--- a/tests/error/runtime_exception_in_solution/expected_results.json
+++ b/tests/error/runtime_exception_in_solution/expected_results.json
@@ -4,7 +4,7 @@
     {
       "name": "identity function of 1",
       "status": "error",
-      "message": "Unhandled exception: myValueError [ValueError]\\n/nim/lib/pure/unittest.nim(646) identity_test\n/tmp/nim_test_runner/identity.nim(2) identity\n",
+      "message": "Unhandled exception: myValueError [ValueError]\\n/nim/lib/pure/unittest.nim(646) test_identity\n/tmp/nim_test_runner/identity.nim(2) identity\n",
       "output": ""
     }
   ]

--- a/tests/fail/multiple_tests_all_fail/expected_results.json
+++ b/tests/fail/multiple_tests_all_fail/expected_results.json
@@ -4,19 +4,19 @@
     {
       "name": "identity function of 1",
       "status": "fail",
-      "message": "/tmp/nim_test_runner/identity_test.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
+      "message": "/tmp/nim_test_runner/test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
       "output": ""
     },
     {
       "name": "identity function of 2",
       "status": "fail",
-      "message": "/tmp/nim_test_runner/identity_test.nim(14, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",
+      "message": "/tmp/nim_test_runner/test_identity.nim(14, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",
       "output": ""
     },
     {
       "name": "identity function of 3",
       "status": "fail",
-      "message": "/tmp/nim_test_runner/identity_test.nim(17, 22): Check failed: identity(3) == 3000\\nidentity(3) was 3",
+      "message": "/tmp/nim_test_runner/test_identity.nim(17, 22): Check failed: identity(3) == 3000\\nidentity(3) was 3",
       "output": ""
     }
   ]

--- a/tests/fail/multiple_tests_multiple_fails/expected_results.json
+++ b/tests/fail/multiple_tests_multiple_fails/expected_results.json
@@ -4,13 +4,13 @@
     {
       "name": "identity function of 1",
       "status": "fail",
-      "message": "/tmp/nim_test_runner/identity_test.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
+      "message": "/tmp/nim_test_runner/test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
       "output": ""
     },
     {
       "name": "identity function of 2",
       "status": "fail",
-      "message": "/tmp/nim_test_runner/identity_test.nim(14, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",
+      "message": "/tmp/nim_test_runner/test_identity.nim(14, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",
       "output": ""
     },
     {

--- a/tests/fail/multiple_tests_one_fail_first/expected_results.json
+++ b/tests/fail/multiple_tests_one_fail_first/expected_results.json
@@ -4,7 +4,7 @@
     {
       "name": "identity function of 1",
       "status": "fail",
-      "message": "/tmp/nim_test_runner/identity_test.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
+      "message": "/tmp/nim_test_runner/test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
       "output": ""
     },
     {

--- a/tests/fail/multiple_tests_one_fail_last/expected_results.json
+++ b/tests/fail/multiple_tests_one_fail_last/expected_results.json
@@ -14,7 +14,7 @@
     {
       "name": "identity function of 3",
       "status": "fail",
-      "message": "/tmp/nim_test_runner/identity_test.nim(17, 22): Check failed: identity(3) == 3000\\nidentity(3) was 3",
+      "message": "/tmp/nim_test_runner/test_identity.nim(17, 22): Check failed: identity(3) == 3000\\nidentity(3) was 3",
       "output": ""
     }
   ]

--- a/tests/fail/multiple_tests_one_fail_middle/expected_results.json
+++ b/tests/fail/multiple_tests_one_fail_middle/expected_results.json
@@ -9,7 +9,7 @@
     {
       "name": "identity function of 2",
       "status": "fail",
-      "message": "/tmp/nim_test_runner/identity_test.nim(14, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",
+      "message": "/tmp/nim_test_runner/test_identity.nim(14, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",
       "output": ""
     },
     {

--- a/tests/fail/single_test/expected_results.json
+++ b/tests/fail/single_test/expected_results.json
@@ -4,7 +4,7 @@
     {
       "name": "identity function of 1",
       "status": "fail",
-      "message": "/tmp/nim_test_runner/identity_test.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
+      "message": "/tmp/nim_test_runner/test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
       "output": ""
     }
   ]

--- a/tests/trunner.nim
+++ b/tests/trunner.nim
@@ -8,7 +8,7 @@ let outputDir = tmpBase / "nim_test_runner_out/"
 for status in ["pass", "fail", "error"]:
   for (kind, path) in walkDir(getAppDir() / status):
     if kind == pcDir:
-      for file in walkFiles(path / "*_test.nim"):
+      for file in walkFiles(path / "test_*.nim"):
         suite status & '/' & path.splitPath().tail:
           let slugUnder = file.splitFile().name[0..^6]
           let slug = slugUnder.replace('_', '-')
@@ -20,7 +20,7 @@ for status in ["pass", "fail", "error"]:
 
           let paths = getPaths(conf)
           test "getPaths: The test path is as expected":
-            check paths.tmpTest == expectedTmpDir / slugUnder & "_test.nim"
+            check paths.tmpTest == expectedTmpDir / "test_" & slugUnder & ".nim"
 
           prepareFiles(paths)
           test "prepareFiles: Copies the input solution":


### PR DESCRIPTION
This PR renames test files to start with `test_`, rather than end with `_test.nim`, reflecting the same change in the `exercism/nim` repo. See: https://github.com/exercism/nim/commit/573ee59fa9530d1d625bf3c265429fe4c25e3fd3

### WIP: 
- [x] Merge https://github.com/exercism/nim-test-runner/pull/29
- [x] then merge https://github.com/exercism/nim-test-runner/pull/27, then rebase this PR on `master`
- [x] Merge https://github.com/exercism/nim/pull/255
- [x] Get CI to pass on this PR (it was previously expected to fail)
- [x] Get approving review from `exercism/maintainers-admin` (pinging @iHiD / @ErikSchierboom )
- [x] Get approving review from someone with write access to this repo