### PR TITLE
CI: Fix smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         # Remove the container.
         docker rm ntr
         # Write the expected output (which does not contain a newline).
-        printf '{"status":"pass","tests":[{"name":"say hi","status":"pass","output":""}]}' \
+        printf '{"status":"pass","tests":[{"name":"say hi!","status":"pass","output":""}]}' \
           > expected_results.json
         # Fail if the output JSON is not as expected.
         diff results.json expected_results.json

--- a/tests/error/compiletime_error_closing_quote_expected/hello_world_test.nim
+++ b/tests/error/compiletime_error_closing_quote_expected/hello_world_test.nim
@@ -4,5 +4,5 @@ import hello_world
 # version 1.1.0
 
 suite "Hello World":
-  test "say hi":
+  test "say hi!":
     check hello() == "Hello, World!"

--- a/tests/pass/single_test/expected_hello_world_test_prepared.nim
+++ b/tests/pass/single_test/expected_hello_world_test_prepared.nim
@@ -9,7 +9,7 @@ let formatter = newJsonOutputFormatter(strm)
 addOutputFormatter(formatter)
 
 suite "Hello World":
-  test "say hi":
+  test "say hi!":
     check hello() == "Hello, World!"
 
 close(formatter)

--- a/tests/pass/single_test/expected_results.json
+++ b/tests/pass/single_test/expected_results.json
@@ -2,7 +2,7 @@
   "status": "pass",
   "tests": [
     {
-      "name": "say hi",
+      "name": "say hi!",
       "status": "pass",
       "output": ""
     }

--- a/tests/pass/single_test/hello_world_test.nim
+++ b/tests/pass/single_test/hello_world_test.nim
@@ -4,5 +4,5 @@ import hello_world
 # version 1.1.0
 
 suite "Hello World":
-  test "say hi":
+  test "say hi!":
     check hello() == "Hello, World!"


### PR DESCRIPTION
The `ci.yml` workflow always fails during the `diff` at the end of:
https://github.com/exercism/nim-test-runner/blob/0870db148b679665697099de5c01ad42e632839b/.github/workflows/ci.yml#L52-L56

because the `hello-world` test name is different from that expected.

The reason: the `exercism/nim` repo changed that test name from `say hi` to `say hi!` to be consistent with the canonical data.

This PR makes the same change.

See: https://github.com/exercism/nim/commit/06e17d1bad64