### PR TITLE
Build(Dockerfile): Compile with LTO, and strip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM nimlang/nim:1.4.0-alpine-slim@sha256:36c84bab9f2020e462604fff06860bebd95310ea065d35d4cc8c755ea30694ae \
      AS builder
 COPY src/runner.nim /build/
-RUN nim c -d:release /build/runner.nim
+RUN nim c -d:release -d:lto -d:strip /build/runner.nim
 
 FROM nimlang/nim:1.4.0-alpine-slim@sha256:36c84bab9f2020e462604fff06860bebd95310ea065d35d4cc8c755ea30694ae
 RUN apk add --no-cache pcre


### PR DESCRIPTION
This PR adds compilation/linking flags that make the `runner` binary smaller and faster.