### PR TITLE
Refactor: Prefer `dirExists` and `fileExists`

### DIFF
--- a/src/runner.nim
+++ b/src/runner.nim
@@ -59,7 +59,7 @@ proc parseCmdLine: Conf =
     writeErrorMsg("inputDir must end in a trailing slash")
   if result.outputDir[^1] != '/':
     writeErrorMsg("outputDir must end in a trailing slash")
-  if not existsDir(result.inputDir):
+  if not dirExists(result.inputDir):
     writeErrorMsg("the inputDir '" & result.inputDir & "' does not exist")
 
 proc createTmpDir: string =

--- a/tests/trunner.nim
+++ b/tests/trunner.nim
@@ -42,7 +42,7 @@ for status in ["pass", "fail", "error"]:
           let resultsJson = parseFile(paths.outResults)
           let pathExpectedResultsJson = path / "expected_results.json"
           test "The `results.json` file is as expected":
-            if existsFile(pathExpectedResultsJson):
+            if fileExists(pathExpectedResultsJson):
               let expectedResultsJson = parseFile(pathExpectedResultsJson)
               if resultsJson != expectedResultsJson:
                 echo "\nresults.json:"

--- a/tests/trunner_repo_solutions.nim
+++ b/tests/trunner_repo_solutions.nim
@@ -7,7 +7,7 @@ proc repoSolutions* =
 
   suite "Run test-runner on the exercises from `exercism/nim`":
     let baseDir = getTempDir() / "exercism-nim"
-    if not existsDir(baseDir):
+    if not dirExists(baseDir):
       let cmd = "git clone --depth 1 https://github.com/exercism/nim.git " &
                 baseDir
       let errC = execCmd(cmd)


### PR DESCRIPTION
This PR resolves some deprecation warnings.

Upstream:
- https://github.com/nim-lang/Nim/commit/79c90b30ee55
- https://github.com/nim-lang/Nim/commit/dc5a40f3f39c
- https://github.com/nim-lang/Nim/commit/695154970d83

[CI log before this PR](https://github.com/exercism/nim-test-runner/runs/1336984449#step:6:15): 
```
/opt/test-runner/src/runner.nim(62, 10) Warning: use dirExists; existsDir is deprecated [Deprecated]
/opt/test-runner/src/runner.nim(25, 6) Hint: 'parseCmdLine' is declared but not used [XDeclaredButNotUsed]
/opt/test-runner/tests/trunner.nim(13, 15) template/generic instantiation of `suite` from here
/opt/test-runner/tests/trunner.nim(44, 16) template/generic instantiation of `test` from here
/opt/test-runner/tests/trunner.nim(45, 16) Warning: use fileExists; existsFile is deprecated [Deprecated]
/opt/test-runner/tests/trunner_repo_solutions.nim(8, 9) template/generic instantiation of `suite` from here
/opt/test-runner/tests/trunner_repo_solutions.nim(10, 12) Warning: use dirExists; existsDir is deprecated [Deprecated]
Hint:  [Link]
Hint: 81367 lines; 2.855s; 117.312MiB peakmem; Debug build; proj: /opt/test-runner/tests/trunner.nim; out: /opt/test-runner/tests/trunner [SuccessX]
Hint: /opt/test-runner/tests/trunner  [Exec]
```

[CI log for this PR](https://github.com/exercism/nim-test-runner/runs/1336990510#step:6:15):
```
/opt/test-runner/src/runner.nim(25, 6) Hint: 'parseCmdLine' is declared but not used [XDeclaredButNotUsed]
Hint:  [Link]
Hint: 81367 lines; 3.277s; 117.309MiB peakmem; Debug build; proj: /opt/test-runner/tests/trunner.nim; out: /opt/test-runner/tests/trunner [SuccessX]
Hint: /opt/test-runner/tests/trunner  [Exec]
```