### PR TITLE
Automatically push Docker image to Docker Hub

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,0 +1,25 @@
+name: Push to DockerHub
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  dockerhub:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - uses: satackey/action-docker-layer-caching@v0.0.5
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v1.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          repository: ${{ github.event.repository.full_name }}
+          tag_with_sha: true
+          tags: latest
+          dockerfile: Dockerfile

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: satackey/action-docker-layer-caching@da67a6cd88114ce3e232893dc6d946efa225aefb # v0.0.8
 
       - name: Build and push Docker images
-        uses: docker/build-push-action@v1.1.0
+        uses: docker/build-push-action@3e7a4f6646880c6f63758d73ac32392d323eaf8f # v1.1.2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - uses: satackey/action-docker-layer-caching@v0.0.5
+      - uses: satackey/action-docker-layer-caching@da67a6cd88114ce3e232893dc6d946efa225aefb # v0.0.8
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v1.1.0


### PR DESCRIPTION
The [v3 development environment](https://github.com/exercism/development-environment/) uses Docker images from Docker Hub for all the tooling.
This allows for easy testing of the various tooling components (analyzers/representer/test-runners).

This PR adds a GitHub Actions workflow to automatically build and push a new Docker image whenever something is merged to master.

See https://github.com/exercism/v3/issues/2727
