### PR TITLE
CI: Disable the deployment job on forked repos

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   multiple-registries:
+    if: github.repository_owner == 'exercism' # Stops this job from running on forks.
     runs-on: ubuntu-latest
 
     env:


### PR DESCRIPTION
Commit 7f854131a4c2 (#37) added a workflow that pushes images to Amazon
ECR and Docker Hub, but the deployment job also ran on forks. This meant
that a push to the `master` branch of a fork would produce a failing CI
check (see e.g. https://github.com/ee7/nim-test-runner/runs/1663523994)

This commit causes the deployment job to be skipped on forks.

I have pushed this diff to the `master` branch of my fork to show that
this PR works - see https://github.com/ee7/nim-test-runner/runs/1667814901