### PR TITLE
Chore: Bump nim from 1.4.0 to 1.4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   job1:
     name: trunner.nim
     runs-on: ubuntu-18.04
-    container: nimlang/nim:1.4.0-ubuntu-regular@sha256:bf508ba3ba8d3407e52b4dfeaea0748e41cd28bec9a91d1f78b0d43e00cd639a
+    container: nimlang/nim:1.4.2-ubuntu-regular@sha256:884e474195e4facb5a5216b85a8f5f6b957e8d05675e24ffc16e6c4657acc069
 
     steps:
     - uses: actions/checkout@aabbfeb2ce60b5bd82389903509092c4648a9713 # v2.2.0
@@ -30,7 +30,7 @@ jobs:
       run: git clone --depth 1 https://github.com/exercism/nim.git
 
     - name: Build image
-      run: docker build -t exercism/nim-test-runner:1.4.0 .
+      run: docker build -t exercism/nim-test-runner:1.4.2 .
 
     - name: Smoke test the image (using the `bin/run.sh` production interface)
       run: |
@@ -39,7 +39,7 @@ jobs:
         # `bin/run.sh` as used in production. Note that the arguments to
         # `bin/run.sh` must come after the image name.
         docker create --name ntr --entrypoint 'bin/run.sh' \
-          exercism/nim-test-runner:1.4.0 hello-world /tmp/ /tmp/out/
+          exercism/nim-test-runner:1.4.2 hello-world /tmp/ /tmp/out/
         # Copy an exercise solution and test file from the `exercism/nim` repo.
         docker cp nim/exercises/hello-world/test_hello_world.nim ntr:/tmp/
         docker cp nim/exercises/hello-world/example.nim ntr:/tmp/hello_world.nim
@@ -59,7 +59,7 @@ jobs:
       run: |
         # Create a container from the image we built, using the `ENTRYPOINT`
         # defined in the Dockerfile.
-        docker create --rm --name ntr exercism/nim-test-runner:1.4.0
+        docker create --rm --name ntr exercism/nim-test-runner:1.4.2
         # Copy the required files and run the tests.
         docker cp src/runner.nim ntr:/opt/test-runner/src/
         docker cp tests/ ntr:/opt/test-runner/tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM nimlang/nim:1.4.0-alpine-slim@sha256:36c84bab9f2020e462604fff06860bebd95310ea065d35d4cc8c755ea30694ae \
+FROM nimlang/nim:1.4.2-alpine-slim@sha256:45cb86ad7b494e381358ae378a04f072f096e11c4e54ed06abdba043fb2667c3 \
      AS builder
 COPY src/runner.nim /build/
 RUN nim c -d:release -d:lto -d:strip /build/runner.nim
 
-FROM nimlang/nim:1.4.0-alpine-slim@sha256:36c84bab9f2020e462604fff06860bebd95310ea065d35d4cc8c755ea30694ae
+FROM nimlang/nim:1.4.2-alpine-slim@sha256:45cb86ad7b494e381358ae378a04f072f096e11c4e54ed06abdba043fb2667c3
 RUN apk add --no-cache pcre
 WORKDIR /opt/test-runner/
 COPY --from=builder /build/runner bin/

--- a/tests/error/compiletime_error_type_mismatch_in_test/expected_results.json
+++ b/tests/error/compiletime_error_type_mismatch_in_test/expected_results.json
@@ -1,5 +1,5 @@
 {
   "status": "error",
-  "message": "/tmp/nim_test_runner/test_identity.nim(9, 7) template/generic instantiation of `suite` from here\n/tmp/nim_test_runner/test_identity.nim(10, 8) template/generic instantiation of `test` from here\n/tmp/nim_test_runner/test_identity.nim(11, 11) template/generic instantiation of `check` from here\n/nim/lib/pure/unittest.nim(646, 43) Error: type mismatch: got <int literal(1)>\nbut expected one of: \nfunc identity(s: string): string\n  first type mismatch at position: 1\n  required type for s: string\n  but expression '1' is of type: int literal(1)\n\nexpression: identity(1)\n",
+  "message": "/tmp/nim_test_runner/test_identity.nim(9, 7) template/generic instantiation of `suite` from here\n/tmp/nim_test_runner/test_identity.nim(10, 8) template/generic instantiation of `test` from here\n/tmp/nim_test_runner/test_identity.nim(11, 11) template/generic instantiation of `check` from here\n/nim/lib/pure/unittest.nim(654, 43) Error: type mismatch: got <int literal(1)>\nbut expected one of: \nfunc identity(s: string): string\n  first type mismatch at position: 1\n  required type for s: string\n  but expression '1' is of type: int literal(1)\n\nexpression: identity(1)\n",
   "tests": []
 }

--- a/tests/error/runtime_exception_in_solution/expected_results.json
+++ b/tests/error/runtime_exception_in_solution/expected_results.json
@@ -4,7 +4,7 @@
     {
       "name": "identity function of 1",
       "status": "error",
-      "message": "Unhandled exception: myValueError [ValueError]\\n/nim/lib/pure/unittest.nim(646) test_identity\n/tmp/nim_test_runner/identity.nim(2) identity\n",
+      "message": "Unhandled exception: myValueError [ValueError]\\n/nim/lib/pure/unittest.nim(654) test_identity\n/tmp/nim_test_runner/identity.nim(2) identity\n",
       "output": ""
     }
   ]


### PR DESCRIPTION
This commit updates our `Dockerfile` and CI workflow to use the latest
stable Nim release.

This also involves updating some expected error messages so that they
match those produced by Nim 1.4.2 - the only changes are to the
`unittest` line numbers.

Release notes: https://nim-lang.org/blog/2020/12/01/version-142-released.html

In a later PR I'll try to refactor the workflow and Dockerfile so that
we can bump the version number and hash in fewer places.