### PR TITLE
Build: Make it easier to bump the Nim version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,29 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+env:
+  NIM_VERSION: 1.4.2
 
 jobs:
   job1:
     name: trunner.nim
     runs-on: ubuntu-18.04
-    container: nimlang/nim:1.4.2-ubuntu-regular@sha256:884e474195e4facb5a5216b85a8f5f6b957e8d05675e24ffc16e6c4657acc069
 
     steps:
     - uses: actions/checkout@aabbfeb2ce60b5bd82389903509092c4648a9713 # v2.2.0
+
+    # Our tests require Nim to be installed to `/nim` because some error messages contain
+    # e.g. `/nim/lib/pure/unittest.nim(654)`.
+    # The `jiro4989/setup-nim-action` action doesn't allow customizing the installation
+    # directory, so let's just install Nim here from the pre-built binaries.
+    - name: Install Nim
+      run: |
+        FILENAME="nim-${NIM_VERSION}-linux_x64.tar.xz"
+        curl -sSfLO --retry 5 "https://nim-lang.org/download/${FILENAME}"
+        tar xf "${FILENAME}"
+        INSTALL_DIR='/nim'
+        sudo mv "nim-${NIM_VERSION}" "${INSTALL_DIR}"
+        echo "${INSTALL_DIR}/bin" >> "${GITHUB_PATH}"
 
     - name: Compile and run `tests/trunner.nim`
       run: "nim c -r --styleCheck:error --hint[Processing]:off tests/trunner.nim"
@@ -30,7 +44,7 @@ jobs:
       run: git clone --depth 1 https://github.com/exercism/nim.git
 
     - name: Build image
-      run: docker build -t exercism/nim-test-runner:1.4.2 .
+      run: docker build -t "exercism/nim-test-runner:${NIM_VERSION}" .
 
     - name: Smoke test the image (using the `bin/run.sh` production interface)
       run: |
@@ -39,7 +53,7 @@ jobs:
         # `bin/run.sh` as used in production. Note that the arguments to
         # `bin/run.sh` must come after the image name.
         docker create --name ntr --entrypoint 'bin/run.sh' \
-          exercism/nim-test-runner:1.4.2 hello-world /tmp/ /tmp/out/
+          "exercism/nim-test-runner:${NIM_VERSION}" hello-world /tmp/ /tmp/out/
         # Copy an exercise solution and test file from the `exercism/nim` repo.
         docker cp nim/exercises/hello-world/test_hello_world.nim ntr:/tmp/
         docker cp nim/exercises/hello-world/example.nim ntr:/tmp/hello_world.nim
@@ -59,7 +73,7 @@ jobs:
       run: |
         # Create a container from the image we built, using the `ENTRYPOINT`
         # defined in the Dockerfile.
-        docker create --rm --name ntr exercism/nim-test-runner:1.4.2
+        docker create --rm --name ntr "exercism/nim-test-runner:${NIM_VERSION}"
         # Copy the required files and run the tests.
         docker cp src/runner.nim ntr:/opt/test-runner/src/
         docker cp tests/ ntr:/opt/test-runner/tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM nimlang/nim:1.4.2-alpine-slim@sha256:45cb86ad7b494e381358ae378a04f072f096e11c4e54ed06abdba043fb2667c3 \
-     AS builder
+ARG NIM_IMAGE=nimlang/nim:1.4.2-alpine-slim@sha256:45cb86ad7b494e381358ae378a04f072f096e11c4e54ed06abdba043fb2667c3
+FROM ${NIM_IMAGE} AS builder
 COPY src/runner.nim /build/
 RUN nim c -d:release -d:lto -d:strip /build/runner.nim
 
-FROM nimlang/nim:1.4.2-alpine-slim@sha256:45cb86ad7b494e381358ae378a04f072f096e11c4e54ed06abdba043fb2667c3
+FROM ${NIM_IMAGE}
 RUN apk add --no-cache pcre
 WORKDIR /opt/test-runner/
 COPY --from=builder /build/runner bin/


### PR DESCRIPTION
This commit refactors the CI workflow and the Dockerfile so that each
defines the desired Nim version only once.

For `ci.yml` it does this by changing the testing-only job to install
Nim directly, rather than using a container with the `ubuntu-regular`
image from `nimlang/nim`. This also makes it more obvious that we're
really using the `alpine-slim` image.

Reference docs:
- https://docs.docker.com/engine/reference/builder/#arg
- https://docs.docker.com/engine/reference/builder/#from