### PR TITLE
Build: Pin ubuntu version as 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   job1:
     name: trunner.nim
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@aabbfeb2ce60b5bd82389903509092c4648a9713 # v2.2.0
@@ -35,7 +35,7 @@ jobs:
 
   job2:
     name: Docker - build image and run
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@aabbfeb2ce60b5bd82389903509092c4648a9713 # v2.2.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   multiple-registries:
     if: github.repository_owner == 'exercism' # Stops this job from running on forks.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     env:
       ECR_REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com


### PR DESCRIPTION
It's unlikely that an automatic Ubuntu update would break things, but we
should pin the major version of GCC along with everything else.

This commit also bumps the Ubuntu version in the CI workflow.