### PR TITLE
CI: Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+
+updates:
+  # Enable updates to the dependencies of our workflows
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: daily
+      time: '15:00'
+
+  # Enable updates to the dependencies of our Dockerfile
+  - package-ecosystem: docker
+    directory: '/'
+    schedule:
+      interval: daily
+      time: '15:00'


### PR DESCRIPTION
Let's use the `interval` of `daily` for the `Dockerfile` so that the base
Nim image is bumped soon after a new Nim release.

The workflow dependencies can be bumped less frequently, but let's make
it `daily` for now just to test.