### PR TITLE
Chore(dependabot): Bump actions on a monthly basis

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,11 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: daily
-      time: '15:00'
+      interval: monthly
 
   # Enable updates to the dependencies of our Dockerfile
   - package-ecosystem: docker
     directory: '/'
     schedule:
       interval: daily
-      time: '15:00'
+      time: '05:00'


### PR DESCRIPTION
Commit ea5e8b81b8c9140f6292e39ad86b33962ee2a4b7 (#43) added Dependabot, initially making it bump workflow dependencies `daily` just for testing purposes:
> The workflow dependencies can be bumped less frequently, but let's make
> it `daily` for now just to test.

The bot then showed that it works: it made two PRs that led to https://github.com/exercism/nim-test-runner/commit/4963d832e430a2b1675b38e57f6b5a90b86f56fe and https://github.com/exercism/nim-test-runner/commit/c18c42f5516fc6bccde7b94d0ecf04a5f072683d being merged (although sadly the comments next to the SHA currently have to be updated manually).

This commit reduces the update `interval` for workflow dependencies so that they're only bumped once a month (on the first day of every month).