### PR TITLE
CI: Add support for Exercism v3 track structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,8 @@ jobs:
         docker create --name ntr --entrypoint 'bin/run.sh' \
           "exercism/nim-test-runner:${NIM_VERSION}" hello-world /tmp/ /tmp/out/
         # Copy an exercise solution and test file from the `exercism/nim` repo.
-        docker cp nim/exercises/hello-world/test_hello_world.nim ntr:/tmp/
-        docker cp nim/exercises/hello-world/example.nim ntr:/tmp/hello_world.nim
+        docker cp nim/exercises/practice/hello-world/test_hello_world.nim ntr:/tmp/
+        docker cp nim/exercises/practice/hello-world/example.nim ntr:/tmp/hello_world.nim
         # Start the container. The runner runs the `hello-world` test.
         docker start -a ntr
         # Copy the runner's JSON output from the container to the host.

--- a/tests/trunner_repo_solutions.nim
+++ b/tests/trunner_repo_solutions.nim
@@ -18,7 +18,7 @@ proc repoSolutions* =
 
     var slugs: CritBitTree[void]
 
-    let exercisesDir = baseDir / "exercises"
+    let exercisesDir = baseDir / "exercises" / "practice"
     for (_, dir) in walkDir(exercisesDir):
       slugs.incl(dir.splitPath().tail)
 


### PR DESCRIPTION
In order to test the Nim test runner, we have been running it on every
exercise from the Nim track repo during CI.

However, as part of the preparation for Exercism v3, the v2 exercises on
every track were moved to a new subdirectory: `exercises/practice`. This
caused our CI to indicate failure as the exercises were no longer found.

This commit updates our CI and tests to use the new location for
practice exercises, making CI green again.

See:
- [this failed CI run](https://github.com/exercism/nim-test-runner/pull/48/checks?check_run_id=1846460952)
- https://github.com/exercism/nim/commit/f7ab39d96e32