### PR TITLE
CI: Update location of `example.nim` files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           "exercism/nim-test-runner:${NIM_VERSION}" hello-world /tmp/ /tmp/out/
         # Copy an exercise solution and test file from the `exercism/nim` repo.
         docker cp nim/exercises/practice/hello-world/test_hello_world.nim ntr:/tmp/
-        docker cp nim/exercises/practice/hello-world/example.nim ntr:/tmp/hello_world.nim
+        docker cp nim/exercises/practice/hello-world/.meta/example.nim ntr:/tmp/hello_world.nim
         # Start the container. The runner runs the `hello-world` test.
         docker start -a ntr
         # Copy the runner's JSON output from the container to the host.

--- a/tests/trunner_repo_solutions.nim
+++ b/tests/trunner_repo_solutions.nim
@@ -27,7 +27,7 @@ proc repoSolutions* =
       test slug:
         let slugDir = exercisesDir / slug
         let slugUnder = slug.replace('-', '_')
-        let exampleContents = readFile(slugDir / "example.nim")
+        let exampleContents = readFile(slugDir / ".meta" / "example.nim")
         let solutionPath = slugDir / slugUnder & ".nim"
         writeFile(solutionPath, exampleContents)
 


### PR DESCRIPTION
In order to test the Nim test runner, we have been running it on every
practice exercise from the Nim track repo during CI.

However, for Exercism v3, the example implementation file for each
practice exercise is now supposed in that exercise's `.meta/`
subdirectory, and the Nim track recently moved those files accordingly.

This commit updates our CI and tests so that each `example.nim` file can
be found in its new location, making CI green again.

See https://github.com/exercism/nim/commit/85527fc3d26b