### PR TITLE
Fix(runner): Simplify paths in `message` values

### DIFF
--- a/tests/error/compiletime_error_closing_quote_expected/expected_results.json
+++ b/tests/error/compiletime_error_closing_quote_expected/expected_results.json
@@ -1,5 +1,5 @@
 {
   "status": "error",
-  "message": "/tmp/nim_test_runner/hello_world.nim(2, 3) Error: closing \" expected\n",
+  "message": "hello_world.nim(2, 3) Error: closing \" expected\n",
   "tests": []
 }

--- a/tests/error/compiletime_error_empty_solution/expected_results.json
+++ b/tests/error/compiletime_error_empty_solution/expected_results.json
@@ -1,5 +1,5 @@
 {
   "status": "error",
-  "message": "/tmp/nim_test_runner/test_identity.nim(9, 7) template/generic instantiation of `suite` from here\n/tmp/nim_test_runner/test_identity.nim(10, 8) template/generic instantiation of `test` from here\n/tmp/nim_test_runner/test_identity.nim(11, 11) Error: undeclared identifier: 'identity'\n",
+  "message": "test_identity.nim(9, 7) template/generic instantiation of `suite` from here\ntest_identity.nim(10, 8) template/generic instantiation of `test` from here\ntest_identity.nim(11, 11) Error: undeclared identifier: 'identity'\n",
   "tests": []
 }

--- a/tests/error/compiletime_error_type_mismatch_in_test/expected_results.json
+++ b/tests/error/compiletime_error_type_mismatch_in_test/expected_results.json
@@ -1,5 +1,5 @@
 {
   "status": "error",
-  "message": "/tmp/nim_test_runner/test_identity.nim(9, 7) template/generic instantiation of `suite` from here\n/tmp/nim_test_runner/test_identity.nim(10, 8) template/generic instantiation of `test` from here\n/tmp/nim_test_runner/test_identity.nim(11, 11) template/generic instantiation of `check` from here\n/nim/lib/pure/unittest.nim(654, 43) Error: type mismatch: got <int literal(1)>\nbut expected one of: \nfunc identity(s: string): string\n  first type mismatch at position: 1\n  required type for s: string\n  but expression '1' is of type: int literal(1)\n\nexpression: identity(1)\n",
+  "message": "test_identity.nim(9, 7) template/generic instantiation of `suite` from here\ntest_identity.nim(10, 8) template/generic instantiation of `test` from here\ntest_identity.nim(11, 11) template/generic instantiation of `check` from here\n/nim/lib/pure/unittest.nim(654, 43) Error: type mismatch: got <int literal(1)>\nbut expected one of: \nfunc identity(s: string): string\n  first type mismatch at position: 1\n  required type for s: string\n  but expression '1' is of type: int literal(1)\n\nexpression: identity(1)\n",
   "tests": []
 }

--- a/tests/error/compiletime_error_undeclared_variable_in_solution/expected_results.json
+++ b/tests/error/compiletime_error_undeclared_variable_in_solution/expected_results.json
@@ -1,5 +1,5 @@
 {
   "status": "error",
-  "message": "/tmp/nim_test_runner/identity.nim(2, 3) Error: undeclared identifier: 'myUndeclaredVariable'\n",
+  "message": "identity.nim(2, 3) Error: undeclared identifier: 'myUndeclaredVariable'\n",
   "tests": []
 }

--- a/tests/error/compiletime_exception_in_solution/expected_results.json
+++ b/tests/error/compiletime_exception_in_solution/expected_results.json
@@ -1,5 +1,5 @@
 {
   "status": "error",
-  "message": "stack trace: (most recent call last)\n/tmp/nim_test_runner/identity.nim(3, 5) identity\n/tmp/nim_test_runner/identity.nim(3, 5) Error: unhandled exception: myValueError [ValueError]\n",
+  "message": "stack trace: (most recent call last)\nidentity.nim(3, 5) identity\nidentity.nim(3, 5) Error: unhandled exception: myValueError [ValueError]\n",
   "tests": []
 }

--- a/tests/error/runtime_exception_in_solution/expected_results.json
+++ b/tests/error/runtime_exception_in_solution/expected_results.json
@@ -4,7 +4,7 @@
     {
       "name": "identity function of 1",
       "status": "error",
-      "message": "Unhandled exception: myValueError [ValueError]\\n/nim/lib/pure/unittest.nim(654) test_identity\n/tmp/nim_test_runner/identity.nim(2) identity\n",
+      "message": "Unhandled exception: myValueError [ValueError]\\n/nim/lib/pure/unittest.nim(654) test_identity\nidentity.nim(2) identity\n",
       "output": ""
     }
   ]

--- a/tests/fail/multiple_tests_all_fail/expected_results.json
+++ b/tests/fail/multiple_tests_all_fail/expected_results.json
@@ -4,19 +4,19 @@
     {
       "name": "identity function of 1",
       "status": "fail",
-      "message": "/tmp/nim_test_runner/test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
+      "message": "test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
       "output": ""
     },
     {
       "name": "identity function of 2",
       "status": "fail",
-      "message": "/tmp/nim_test_runner/test_identity.nim(14, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",
+      "message": "test_identity.nim(14, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",
       "output": ""
     },
     {
       "name": "identity function of 3",
       "status": "fail",
-      "message": "/tmp/nim_test_runner/test_identity.nim(17, 22): Check failed: identity(3) == 3000\\nidentity(3) was 3",
+      "message": "test_identity.nim(17, 22): Check failed: identity(3) == 3000\\nidentity(3) was 3",
       "output": ""
     }
   ]

--- a/tests/fail/multiple_tests_multiple_fails/expected_results.json
+++ b/tests/fail/multiple_tests_multiple_fails/expected_results.json
@@ -4,13 +4,13 @@
     {
       "name": "identity function of 1",
       "status": "fail",
-      "message": "/tmp/nim_test_runner/test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
+      "message": "test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
       "output": ""
     },
     {
       "name": "identity function of 2",
       "status": "fail",
-      "message": "/tmp/nim_test_runner/test_identity.nim(14, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",
+      "message": "test_identity.nim(14, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",
       "output": ""
     },
     {

--- a/tests/fail/multiple_tests_multiple_fails_output/expected_results.json
+++ b/tests/fail/multiple_tests_multiple_fails_output/expected_results.json
@@ -4,13 +4,13 @@
     {
       "name": "identity function of 1",
       "status": "fail",
-      "message": "/tmp/nim_test_runner/test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
+      "message": "test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
       "output": "stdout here: my input is: 1\nstderr here: my input is: 1\n"
     },
     {
       "name": "identity function of 2",
       "status": "fail",
-      "message": "/tmp/nim_test_runner/test_identity.nim(14, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",
+      "message": "test_identity.nim(14, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",
       "output": "stdout here: my input is: 2\nstderr here: my input is: 2\n"
     },
     {

--- a/tests/fail/multiple_tests_one_fail_first/expected_results.json
+++ b/tests/fail/multiple_tests_one_fail_first/expected_results.json
@@ -4,7 +4,7 @@
     {
       "name": "identity function of 1",
       "status": "fail",
-      "message": "/tmp/nim_test_runner/test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
+      "message": "test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
       "output": ""
     },
     {

--- a/tests/fail/multiple_tests_one_fail_last/expected_results.json
+++ b/tests/fail/multiple_tests_one_fail_last/expected_results.json
@@ -14,7 +14,7 @@
     {
       "name": "identity function of 3",
       "status": "fail",
-      "message": "/tmp/nim_test_runner/test_identity.nim(17, 22): Check failed: identity(3) == 3000\\nidentity(3) was 3",
+      "message": "test_identity.nim(17, 22): Check failed: identity(3) == 3000\\nidentity(3) was 3",
       "output": ""
     }
   ]

--- a/tests/fail/multiple_tests_one_fail_middle/expected_results.json
+++ b/tests/fail/multiple_tests_one_fail_middle/expected_results.json
@@ -9,7 +9,7 @@
     {
       "name": "identity function of 2",
       "status": "fail",
-      "message": "/tmp/nim_test_runner/test_identity.nim(14, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",
+      "message": "test_identity.nim(14, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",
       "output": ""
     },
     {

--- a/tests/fail/single_test/expected_results.json
+++ b/tests/fail/single_test/expected_results.json
@@ -4,7 +4,7 @@
     {
       "name": "identity function of 1",
       "status": "fail",
-      "message": "/tmp/nim_test_runner/test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
+      "message": "test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
       "output": ""
     }
   ]

--- a/tests/fail/single_test_output/expected_results.json
+++ b/tests/fail/single_test_output/expected_results.json
@@ -4,7 +4,7 @@
     {
       "name": "identity function of 1",
       "status": "fail",
-      "message": "/tmp/nim_test_runner/test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
+      "message": "test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
       "output": "stdout here: my input is: 1\nstderr here: my input is: 1\n"
     }
   ]


### PR DESCRIPTION
Closes: #14

---

With this PR, the values of our `message` keys are:

```
tests/error/compiletime_crash_in_solution/expected_results.json
3:  "message": "Error: internal error: getTypeDescAux(tyEmpty)\nNo stack traceback available\nTo create a stacktrace, rerun compilation with './koch temp c <file>', see https://nim-lang.github.io/Nim/intern.html#debugging-the-compiler for details\n",

tests/error/compiletime_error_closing_quote_expected/expected_results.json
3:  "message": "hello_world.nim(2, 3) Error: closing \" expected\n",

tests/error/compiletime_error_empty_solution/expected_results.json
3:  "message": "test_identity.nim(9, 7) template/generic instantiation of `suite` from here\ntest_identity.nim(10, 8) template/generic instantiation of `test` from here\ntest_identity.nim(11, 11) Error: undeclared identifier: 'identity'\n",

tests/error/compiletime_error_type_mismatch_in_test/expected_results.json
3:  "message": "test_identity.nim(9, 7) template/generic instantiation of `suite` from here\ntest_identity.nim(10, 8) template/generic instantiation of `test` from here\ntest_identity.nim(11, 11) template/generic instantiation of `check` from here\n/nim/lib/pure/unittest.nim(654, 43) Error: type mismatch: got <int literal(1)>\nbut expected one of: \nfunc identity(s: string): string\n  first type mismatch at position: 1\n  required type for s: string\n  but expression '1' is of type: int literal(1)\n\nexpre→

tests/error/compiletime_error_undeclared_variable_in_solution/expected_results.json
3:  "message": "identity.nim(2, 3) Error: undeclared identifier: 'myUndeclaredVariable'\n",

tests/error/compiletime_exception_in_solution/expected_results.json
3:  "message": "stack trace: (most recent call last)\nidentity.nim(3, 5) identity\nidentity.nim(3, 5) Error: unhandled exception: myValueError [ValueError]\n",

tests/error/runtime_exception_in_solution/expected_results.json
7:      "message": "Unhandled exception: myValueError [ValueError]\\n/nim/lib/pure/unittest.nim(654) test_identity\nidentity.nim(2) identity\n",

tests/fail/multiple_tests_all_fail/expected_results.json
7:      "message": "test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
13:      "message": "test_identity.nim(14, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",
19:      "message": "test_identity.nim(17, 22): Check failed: identity(3) == 3000\\nidentity(3) was 3",

tests/fail/multiple_tests_multiple_fails/expected_results.json
7:      "message": "test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
13:      "message": "test_identity.nim(14, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",

tests/fail/multiple_tests_multiple_fails_output/expected_results.json
7:      "message": "test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
13:      "message": "test_identity.nim(14, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",

tests/fail/multiple_tests_one_fail_first/expected_results.json
7:      "message": "test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",

tests/fail/multiple_tests_one_fail_last/expected_results.json
17:      "message": "test_identity.nim(17, 22): Check failed: identity(3) == 3000\\nidentity(3) was 3",

tests/fail/multiple_tests_one_fail_middle/expected_results.json
12:      "message": "test_identity.nim(14, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",

tests/fail/single_test/expected_results.json
7:      "message": "test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",

tests/fail/single_test_output/expected_results.json
7:      "message": "test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
```