### PR TITLE
results.json: add `version` property

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         # Remove the container.
         docker rm ntr
         # Write the expected output (which does not contain a newline).
-        printf '{"status":"pass","tests":[{"name":"say hi!","status":"pass","output":""}]}' \
+        printf '{"version":2,"status":"pass","tests":[{"name":"say hi!","status":"pass","output":""}]}' \
           > expected_results.json
         # Fail if the output JSON is not as expected.
         diff results.json expected_results.json

--- a/src/runner.nim
+++ b/src/runner.nim
@@ -115,7 +115,7 @@ proc writeTopLevelErrorJson(path: string, message: string) =
   ## top-level message of `message`.
   var message = escapeJson(message)
   simplifyPaths message
-  let contents = """{"status": "error", "message": """ & message &
+  let contents = """{"version": 2, "status": "error", "message": """ & message &
                  """, "tests": []}"""
   writeFile(path, contents)
 

--- a/src/unittest_json.nim
+++ b/src/unittest_json.nim
@@ -18,6 +18,7 @@ type
     output: string
 
   ResultJson = ref object
+    version: int
     case status: JsonTestStatus
     of ERROR:
       message: string
@@ -31,6 +32,9 @@ type
     testStackTrace: string
     result: ResultJson
 
+const
+  specVersion = 2
+
 proc newJsonOutputFormatter*(stream: Stream): <//>JsonOutputFormatter =
   ## Creates a formatter that writes report to the specified stream in
   ## JSON format.
@@ -41,7 +45,7 @@ proc newJsonOutputFormatter*(stream: Stream): <//>JsonOutputFormatter =
     stream: stream,
     testErrors: @[],
     testStackTrace: "",
-    result: ResultJson(tests: @[], status: PASS)
+    result: ResultJson(version: specVersion, status: PASS, tests: @[])
   )
 
 proc close*(formatter: JsonOutputFormatter) =
@@ -110,7 +114,9 @@ method testEnded(formatter: JsonOutputFormatter, testResult: TestResult) =
         status: FAIL,
         message: fmt"{failureMsg}\n{errs}"
       )
-    formatter.result = ResultJson(status: FAIL, tests: formatter.result.tests)
+    formatter.result = ResultJson(version: specVersion,
+                                  status: FAIL,
+                                  tests: formatter.result.tests)
 
   formatter.result.tests.add(jsonTestResult)
 

--- a/tests/error/compiletime_crash_in_solution/expected_results.json
+++ b/tests/error/compiletime_crash_in_solution/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "error",
   "message": "Error: internal error: getTypeDescAux(tyEmpty)\nNo stack traceback available\nTo create a stacktrace, rerun compilation with './koch temp c <file>', see https://nim-lang.github.io/Nim/intern.html#debugging-the-compiler for details\n",
   "tests": []

--- a/tests/error/compiletime_error_closing_quote_expected/expected_results.json
+++ b/tests/error/compiletime_error_closing_quote_expected/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "error",
   "message": "hello_world.nim(2, 3) Error: closing \" expected\n",
   "tests": []

--- a/tests/error/compiletime_error_empty_solution/expected_results.json
+++ b/tests/error/compiletime_error_empty_solution/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "error",
   "message": "test_identity.nim(9, 7) template/generic instantiation of `suite` from here\ntest_identity.nim(10, 8) template/generic instantiation of `test` from here\ntest_identity.nim(11, 11) Error: undeclared identifier: 'identity'\n",
   "tests": []

--- a/tests/error/compiletime_error_type_mismatch_in_test/expected_results.json
+++ b/tests/error/compiletime_error_type_mismatch_in_test/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "error",
   "message": "test_identity.nim(9, 7) template/generic instantiation of `suite` from here\ntest_identity.nim(10, 8) template/generic instantiation of `test` from here\ntest_identity.nim(11, 11) template/generic instantiation of `check` from here\n/nim/lib/pure/unittest.nim(654, 43) Error: type mismatch: got <int literal(1)>\nbut expected one of: \nfunc identity(s: string): string\n  first type mismatch at position: 1\n  required type for s: string\n  but expression '1' is of type: int literal(1)\n\nexpression: identity(1)\n",
   "tests": []

--- a/tests/error/compiletime_error_undeclared_variable_in_solution/expected_results.json
+++ b/tests/error/compiletime_error_undeclared_variable_in_solution/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "error",
   "message": "identity.nim(2, 3) Error: undeclared identifier: 'myUndeclaredVariable'\n",
   "tests": []

--- a/tests/error/compiletime_exception_in_solution/expected_results.json
+++ b/tests/error/compiletime_exception_in_solution/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "error",
   "message": "stack trace: (most recent call last)\nidentity.nim(3, 5) identity\nidentity.nim(3, 5) Error: unhandled exception: myValueError [ValueError]\n",
   "tests": []

--- a/tests/error/runtime_exception_in_solution/expected_results.json
+++ b/tests/error/runtime_exception_in_solution/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "fail",
   "tests": [
     {

--- a/tests/fail/multiple_tests_all_fail/expected_results.json
+++ b/tests/fail/multiple_tests_all_fail/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "fail",
   "tests": [
     {

--- a/tests/fail/multiple_tests_multiple_fails/expected_results.json
+++ b/tests/fail/multiple_tests_multiple_fails/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "fail",
   "tests": [
     {

--- a/tests/fail/multiple_tests_multiple_fails_output/expected_results.json
+++ b/tests/fail/multiple_tests_multiple_fails_output/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "fail",
   "tests": [
     {

--- a/tests/fail/multiple_tests_one_fail_first/expected_results.json
+++ b/tests/fail/multiple_tests_one_fail_first/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "fail",
   "tests": [
     {

--- a/tests/fail/multiple_tests_one_fail_last/expected_results.json
+++ b/tests/fail/multiple_tests_one_fail_last/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "fail",
   "tests": [
     {

--- a/tests/fail/multiple_tests_one_fail_middle/expected_results.json
+++ b/tests/fail/multiple_tests_one_fail_middle/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "fail",
   "tests": [
     {

--- a/tests/fail/single_test/expected_results.json
+++ b/tests/fail/single_test/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "fail",
   "tests": [
     {

--- a/tests/fail/single_test_output/expected_results.json
+++ b/tests/fail/single_test_output/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "fail",
   "tests": [
     {

--- a/tests/pass/multiple_tests/expected_results.json
+++ b/tests/pass/multiple_tests/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "pass",
   "tests": [
     {

--- a/tests/pass/multiple_tests_output/expected_results.json
+++ b/tests/pass/multiple_tests_output/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "pass",
   "tests": [
     {

--- a/tests/pass/multiple_tests_output_truncated/expected_results.json
+++ b/tests/pass/multiple_tests_output_truncated/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "pass",
   "tests": [
     {

--- a/tests/pass/multiple_tests_output_unicode_truncated/expected_results.json
+++ b/tests/pass/multiple_tests_output_unicode_truncated/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "pass",
   "tests": [
     {

--- a/tests/pass/single_test/expected_results.json
+++ b/tests/pass/single_test/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "pass",
   "tests": [
     {

--- a/tests/pass/single_test_output/expected_results.json
+++ b/tests/pass/single_test_output/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "pass",
   "tests": [
     {

--- a/tests/pass/single_test_output_stderr_only/expected_results.json
+++ b/tests/pass/single_test_output_stderr_only/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "pass",
   "tests": [
     {

--- a/tests/pass/single_test_output_unicode/expected_results.json
+++ b/tests/pass/single_test_output_unicode/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "pass",
   "tests": [
     {


### PR DESCRIPTION
See [the spec](https://github.com/exercism/docs/blob/main/anatomy/track-tooling/test-runners/interface.md#output-format).

Note that we don't yet add the `test_code` property to our `results.json`, so this PR might be a little premature. 