### PR TITLE
refactor: use `std/` import prefix

### DIFF
--- a/src/runner.nim
+++ b/src/runner.nim
@@ -1,4 +1,5 @@
-import json, os, osproc, parseopt, parseutils, sequtils, strutils, terminal, unicode
+import std/[json, os, osproc, parseopt, parseutils, sequtils, strutils,
+            terminal, unicode]
 
 proc writeHelp =
   echo """Usage:
@@ -131,7 +132,7 @@ addOutputFormatter(formatter)
   const afterTests = "\nclose(formatter)\n"
 
   var isBeforeFirstSuite = true
-  var editedTestContents = "import streams, unittest_json\n"
+  var editedTestContents = "import std/streams\nimport unittest_json\n"
 
   for line in lines(paths.inputTest):
     if isBeforeFirstSuite and line.startsWith("suite"):

--- a/src/unittest_json.nim
+++ b/src/unittest_json.nim
@@ -1,6 +1,6 @@
 ## An extension of the ``unittest.nim`` library to output json for Exercism v3
 
-import json, streams, strformat, unittest
+import std/[json, streams, strformat, unittest]
 
 type
   JsonTestStatus = enum

--- a/tests/error/compiletime_crash_in_solution/test_identity.nim
+++ b/tests/error/compiletime_crash_in_solution/test_identity.nim
@@ -1,4 +1,4 @@
-import unittest
+import std/unittest
 import identity
 
 suite "Identity Function":

--- a/tests/error/compiletime_error_closing_quote_expected/test_hello_world.nim
+++ b/tests/error/compiletime_error_closing_quote_expected/test_hello_world.nim
@@ -1,4 +1,4 @@
-import unittest
+import std/unittest
 import hello_world
 
 # version 1.1.0

--- a/tests/error/compiletime_error_empty_solution/expected_results.json
+++ b/tests/error/compiletime_error_empty_solution/expected_results.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
   "status": "error",
-  "message": "test_identity.nim(9, 7) template/generic instantiation of `suite` from here\ntest_identity.nim(10, 8) template/generic instantiation of `test` from here\ntest_identity.nim(11, 11) Error: undeclared identifier: 'identity'\n",
+  "message": "test_identity.nim(10, 7) template/generic instantiation of `suite` from here\ntest_identity.nim(11, 8) template/generic instantiation of `test` from here\ntest_identity.nim(12, 11) Error: undeclared identifier: 'identity'\n",
   "tests": []
 }

--- a/tests/error/compiletime_error_empty_solution/test_identity.nim
+++ b/tests/error/compiletime_error_empty_solution/test_identity.nim
@@ -1,4 +1,4 @@
-import unittest
+import std/unittest
 import identity
 
 suite "Identity Function":

--- a/tests/error/compiletime_error_type_mismatch_in_test/expected_results.json
+++ b/tests/error/compiletime_error_type_mismatch_in_test/expected_results.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
   "status": "error",
-  "message": "test_identity.nim(9, 7) template/generic instantiation of `suite` from here\ntest_identity.nim(10, 8) template/generic instantiation of `test` from here\ntest_identity.nim(11, 11) template/generic instantiation of `check` from here\n/nim/lib/pure/unittest.nim(654, 43) Error: type mismatch: got <int literal(1)>\nbut expected one of: \nfunc identity(s: string): string\n  first type mismatch at position: 1\n  required type for s: string\n  but expression '1' is of type: int literal(1)\n\nexpression: identity(1)\n",
+  "message": "test_identity.nim(10, 7) template/generic instantiation of `suite` from here\ntest_identity.nim(11, 8) template/generic instantiation of `test` from here\ntest_identity.nim(12, 11) template/generic instantiation of `check` from here\n/nim/lib/pure/unittest.nim(654, 43) Error: type mismatch: got <int literal(1)>\nbut expected one of: \nfunc identity(s: string): string\n  first type mismatch at position: 1\n  required type for s: string\n  but expression '1' is of type: int literal(1)\n\nexpression: identity(1)\n",
   "tests": []
 }

--- a/tests/error/compiletime_error_type_mismatch_in_test/test_identity.nim
+++ b/tests/error/compiletime_error_type_mismatch_in_test/test_identity.nim
@@ -1,4 +1,4 @@
-import unittest
+import std/unittest
 import identity
 
 suite "Identity Function":

--- a/tests/error/compiletime_error_undeclared_variable_in_solution/test_identity.nim
+++ b/tests/error/compiletime_error_undeclared_variable_in_solution/test_identity.nim
@@ -1,4 +1,4 @@
-import unittest
+import std/unittest
 import identity
 
 suite "Identity Function":

--- a/tests/error/compiletime_exception_in_solution/test_identity.nim
+++ b/tests/error/compiletime_exception_in_solution/test_identity.nim
@@ -1,4 +1,4 @@
-import unittest
+import std/unittest
 import identity
 
 suite "Identity Function":

--- a/tests/error/runtime_exception_in_solution/test_identity.nim
+++ b/tests/error/runtime_exception_in_solution/test_identity.nim
@@ -1,4 +1,4 @@
-import unittest
+import std/unittest
 import identity
 
 suite "Identity Function":

--- a/tests/fail/multiple_tests_all_fail/expected_results.json
+++ b/tests/fail/multiple_tests_all_fail/expected_results.json
@@ -5,19 +5,19 @@
     {
       "name": "identity function of 1",
       "status": "fail",
-      "message": "test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
+      "message": "test_identity.nim(12, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
       "output": ""
     },
     {
       "name": "identity function of 2",
       "status": "fail",
-      "message": "test_identity.nim(14, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",
+      "message": "test_identity.nim(15, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",
       "output": ""
     },
     {
       "name": "identity function of 3",
       "status": "fail",
-      "message": "test_identity.nim(17, 22): Check failed: identity(3) == 3000\\nidentity(3) was 3",
+      "message": "test_identity.nim(18, 22): Check failed: identity(3) == 3000\\nidentity(3) was 3",
       "output": ""
     }
   ]

--- a/tests/fail/multiple_tests_all_fail/test_identity.nim
+++ b/tests/fail/multiple_tests_all_fail/test_identity.nim
@@ -1,4 +1,4 @@
-import unittest
+import std/unittest
 import identity
 
 suite "Identity Function":

--- a/tests/fail/multiple_tests_multiple_fails/expected_results.json
+++ b/tests/fail/multiple_tests_multiple_fails/expected_results.json
@@ -5,13 +5,13 @@
     {
       "name": "identity function of 1",
       "status": "fail",
-      "message": "test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
+      "message": "test_identity.nim(12, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
       "output": ""
     },
     {
       "name": "identity function of 2",
       "status": "fail",
-      "message": "test_identity.nim(14, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",
+      "message": "test_identity.nim(15, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",
       "output": ""
     },
     {

--- a/tests/fail/multiple_tests_multiple_fails/test_identity.nim
+++ b/tests/fail/multiple_tests_multiple_fails/test_identity.nim
@@ -1,4 +1,4 @@
-import unittest
+import std/unittest
 import identity
 
 suite "Identity Function":

--- a/tests/fail/multiple_tests_multiple_fails_output/expected_results.json
+++ b/tests/fail/multiple_tests_multiple_fails_output/expected_results.json
@@ -5,13 +5,13 @@
     {
       "name": "identity function of 1",
       "status": "fail",
-      "message": "test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
+      "message": "test_identity.nim(12, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
       "output": "stdout here: my input is: 1\nstderr here: my input is: 1\n"
     },
     {
       "name": "identity function of 2",
       "status": "fail",
-      "message": "test_identity.nim(14, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",
+      "message": "test_identity.nim(15, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",
       "output": "stdout here: my input is: 2\nstderr here: my input is: 2\n"
     },
     {

--- a/tests/fail/multiple_tests_multiple_fails_output/test_identity.nim
+++ b/tests/fail/multiple_tests_multiple_fails_output/test_identity.nim
@@ -1,4 +1,4 @@
-import unittest
+import std/unittest
 import identity
 
 suite "Identity Function":

--- a/tests/fail/multiple_tests_one_fail_first/expected_results.json
+++ b/tests/fail/multiple_tests_one_fail_first/expected_results.json
@@ -5,7 +5,7 @@
     {
       "name": "identity function of 1",
       "status": "fail",
-      "message": "test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
+      "message": "test_identity.nim(12, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
       "output": ""
     },
     {

--- a/tests/fail/multiple_tests_one_fail_first/test_identity.nim
+++ b/tests/fail/multiple_tests_one_fail_first/test_identity.nim
@@ -1,4 +1,4 @@
-import unittest
+import std/unittest
 import identity
 
 suite "Identity Function":

--- a/tests/fail/multiple_tests_one_fail_last/expected_results.json
+++ b/tests/fail/multiple_tests_one_fail_last/expected_results.json
@@ -15,7 +15,7 @@
     {
       "name": "identity function of 3",
       "status": "fail",
-      "message": "test_identity.nim(17, 22): Check failed: identity(3) == 3000\\nidentity(3) was 3",
+      "message": "test_identity.nim(18, 22): Check failed: identity(3) == 3000\\nidentity(3) was 3",
       "output": ""
     }
   ]

--- a/tests/fail/multiple_tests_one_fail_last/test_identity.nim
+++ b/tests/fail/multiple_tests_one_fail_last/test_identity.nim
@@ -1,4 +1,4 @@
-import unittest
+import std/unittest
 import identity
 
 suite "Identity Function":

--- a/tests/fail/multiple_tests_one_fail_middle/expected_results.json
+++ b/tests/fail/multiple_tests_one_fail_middle/expected_results.json
@@ -10,7 +10,7 @@
     {
       "name": "identity function of 2",
       "status": "fail",
-      "message": "test_identity.nim(14, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",
+      "message": "test_identity.nim(15, 22): Check failed: identity(2) == 2000\\nidentity(2) was 2",
       "output": ""
     },
     {

--- a/tests/fail/multiple_tests_one_fail_middle/test_identity.nim
+++ b/tests/fail/multiple_tests_one_fail_middle/test_identity.nim
@@ -1,4 +1,4 @@
-import unittest
+import std/unittest
 import identity
 
 suite "Identity Function":

--- a/tests/fail/single_test/expected_results.json
+++ b/tests/fail/single_test/expected_results.json
@@ -5,7 +5,7 @@
     {
       "name": "identity function of 1",
       "status": "fail",
-      "message": "test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
+      "message": "test_identity.nim(12, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
       "output": ""
     }
   ]

--- a/tests/fail/single_test/test_identity.nim
+++ b/tests/fail/single_test/test_identity.nim
@@ -1,4 +1,4 @@
-import unittest
+import std/unittest
 import identity
 
 suite "Identity Function":

--- a/tests/fail/single_test_output/expected_results.json
+++ b/tests/fail/single_test_output/expected_results.json
@@ -5,7 +5,7 @@
     {
       "name": "identity function of 1",
       "status": "fail",
-      "message": "test_identity.nim(11, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
+      "message": "test_identity.nim(12, 22): Check failed: identity(1) == 1000\\nidentity(1) was 1",
       "output": "stdout here: my input is: 1\nstderr here: my input is: 1\n"
     }
   ]

--- a/tests/fail/single_test_output/test_identity.nim
+++ b/tests/fail/single_test_output/test_identity.nim
@@ -1,4 +1,4 @@
-import unittest
+import std/unittest
 import identity
 
 suite "Identity Function":

--- a/tests/pass/multiple_tests/test_identity.nim
+++ b/tests/pass/multiple_tests/test_identity.nim
@@ -1,4 +1,4 @@
-import unittest
+import std/unittest
 import identity
 
 suite "Identity Function":

--- a/tests/pass/multiple_tests_output/test_identity.nim
+++ b/tests/pass/multiple_tests_output/test_identity.nim
@@ -1,4 +1,4 @@
-import unittest
+import std/unittest
 import identity
 
 suite "Identity Function":

--- a/tests/pass/multiple_tests_output_truncated/identity.nim
+++ b/tests/pass/multiple_tests_output_truncated/identity.nim
@@ -1,4 +1,4 @@
-import strutils
+import std/strutils
 
 const longString = "_123456789".repeat(50)
 doAssert longString.len == 500

--- a/tests/pass/multiple_tests_output_truncated/test_identity.nim
+++ b/tests/pass/multiple_tests_output_truncated/test_identity.nim
@@ -1,4 +1,4 @@
-import unittest
+import std/unittest
 import identity
 
 suite "Identity Function":

--- a/tests/pass/multiple_tests_output_unicode_truncated/identity.nim
+++ b/tests/pass/multiple_tests_output_unicode_truncated/identity.nim
@@ -1,4 +1,4 @@
-import strutils, unicode
+import std/[strutils, unicode]
 
 const
   longString = "_➊➋➌➍➎➏➐➑➒".repeat(50)

--- a/tests/pass/multiple_tests_output_unicode_truncated/test_identity.nim
+++ b/tests/pass/multiple_tests_output_unicode_truncated/test_identity.nim
@@ -1,4 +1,4 @@
-import unittest
+import std/unittest
 import identity
 
 suite "Identity Function":

--- a/tests/pass/single_test/expected_test_hello_world_prepared.nim
+++ b/tests/pass/single_test/expected_test_hello_world_prepared.nim
@@ -1,5 +1,6 @@
-import streams, unittest_json
-import unittest
+import std/streams
+import unittest_json
+import std/unittest
 import hello_world
 
 # version 1.1.0

--- a/tests/pass/single_test/test_hello_world.nim
+++ b/tests/pass/single_test/test_hello_world.nim
@@ -1,4 +1,4 @@
-import unittest
+import std/unittest
 import hello_world
 
 # version 1.1.0

--- a/tests/pass/single_test_output/test_identity.nim
+++ b/tests/pass/single_test_output/test_identity.nim
@@ -1,4 +1,4 @@
-import unittest
+import std/unittest
 import identity
 
 suite "Identity Function":

--- a/tests/pass/single_test_output_stderr_only/test_identity.nim
+++ b/tests/pass/single_test_output_stderr_only/test_identity.nim
@@ -1,4 +1,4 @@
-import unittest
+import std/unittest
 import identity
 
 suite "Identity Function":

--- a/tests/pass/single_test_output_unicode/test_identity.nim
+++ b/tests/pass/single_test_output_unicode/test_identity.nim
@@ -1,4 +1,4 @@
-import unittest
+import std/unittest
 import identity
 
 suite "Identity Function":

--- a/tests/trunner.nim
+++ b/tests/trunner.nim
@@ -1,4 +1,4 @@
-import json, os, strutils, unittest
+import std/[json, os, strutils, unittest]
 import runner
 
 let tmpBase = getTempDir()

--- a/tests/trunner_repo_solutions.nim
+++ b/tests/trunner_repo_solutions.nim
@@ -1,4 +1,4 @@
-import critbits, json, os, osproc, strutils, unittest
+import std/[critbits, json, os, osproc, strutils, unittest]
 import runner
 
 proc repoSolutions* =


### PR DESCRIPTION
This has been considered a good practice for a while, and it's recently
been included in the official style guide.

See https://github.com/nim-lang/Nim/commit/1efaef52a2f9

---

With this PR, searching repo files for `import`:
```
src/runner.nim
1:import std/[json, os, osproc, parseopt, parseutils, sequtils, strutils,
135:  var editedTestContents = "import std/streams\nimport unittest_json\n"

src/unittest_json.nim
3:import std/[json, streams, strformat, unittest]

tests/error/compiletime_crash_in_solution/test_identity.nim
1:import std/unittest
2:import identity

tests/error/compiletime_error_closing_quote_expected/test_hello_world.nim
1:import std/unittest
2:import hello_world

tests/error/compiletime_error_empty_solution/test_identity.nim
1:import std/unittest
2:import identity

tests/error/compiletime_error_type_mismatch_in_test/test_identity.nim
1:import std/unittest
2:import identity

tests/error/compiletime_error_undeclared_variable_in_solution/test_identity.nim
1:import std/unittest
2:import identity

tests/error/compiletime_exception_in_solution/test_identity.nim
1:import std/unittest
2:import identity

tests/error/runtime_exception_in_solution/test_identity.nim
1:import std/unittest
2:import identity

tests/fail/multiple_tests_all_fail/test_identity.nim
1:import std/unittest
2:import identity

tests/fail/multiple_tests_multiple_fails/test_identity.nim
1:import std/unittest
2:import identity

tests/fail/multiple_tests_multiple_fails_output/test_identity.nim
1:import std/unittest
2:import identity

tests/fail/multiple_tests_one_fail_first/test_identity.nim
1:import std/unittest
2:import identity

tests/fail/multiple_tests_one_fail_last/test_identity.nim
1:import std/unittest
2:import identity

tests/fail/multiple_tests_one_fail_middle/test_identity.nim
1:import std/unittest
2:import identity

tests/fail/single_test/test_identity.nim
1:import std/unittest
2:import identity

tests/fail/single_test_output/test_identity.nim
1:import std/unittest
2:import identity

tests/pass/multiple_tests/test_identity.nim
1:import std/unittest
2:import identity

tests/pass/multiple_tests_output/test_identity.nim
1:import std/unittest
2:import identity

tests/pass/multiple_tests_output_truncated/identity.nim
1:import std/strutils

tests/pass/multiple_tests_output_truncated/test_identity.nim
1:import std/unittest
2:import identity

tests/pass/multiple_tests_output_unicode_truncated/identity.nim
1:import std/[strutils, unicode]

tests/pass/multiple_tests_output_unicode_truncated/test_identity.nim
1:import std/unittest
2:import identity

tests/pass/single_test/expected_test_hello_world_prepared.nim
1:import std/streams
2:import unittest_json
3:import std/unittest
4:import hello_world

tests/pass/single_test/test_hello_world.nim
1:import std/unittest
2:import hello_world

tests/pass/single_test_output/test_identity.nim
1:import std/unittest
2:import identity

tests/pass/single_test_output_stderr_only/test_identity.nim
1:import std/unittest
2:import identity

tests/pass/single_test_output_unicode/test_identity.nim
1:import std/unittest
2:import identity

tests/trunner.nim
1:import std/[json, os, strutils, unittest]
2:import runner
64:  import trunner_repo_solutions

tests/trunner_repo_solutions.nim
1:import std/[critbits, json, os, osproc, strutils, unittest]
2:import runner
```