### PR TITLE
runner: fix doc comment

### DIFF
--- a/src/runner.nim
+++ b/src/runner.nim
@@ -195,8 +195,8 @@ proc writeOutput*(resultsFileName, runtimeOutput: string) =
   resultsFileName.writeFile $testResults
 
 proc run*(paths: Paths): tuple[output: string, exitCode: int] =
-  ## Compiles and runs the file in `testPath`. Returns its exit code and the
-  ## run-time output (which is empty if compilation fails).
+  ## Compiles and runs the file in `paths.tmpTest`. Returns its exit code and
+  ## the run-time output (which is empty if compilation fails).
   let (compMsgs, exitCode1) = execCmdEx("nim c --styleCheck:hint " &
                                         "--skipUserCfg:on --verbosity:0 " &
                                         "--hint[Processing]:off " &


### PR DESCRIPTION
This commit fixes an oversight from 3a325057b118 (#21) - the doc comment
for this proc should have been updated.