### PR TITLE
build: bump Nim from 1.4.2 to 1.4.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     paths-ignore:
       - '**.md'
 env:
-  NIM_VERSION: 1.4.2
+  NIM_VERSION: 1.4.4
 
 jobs:
   job1:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NIM_IMAGE=nimlang/nim:1.4.2-alpine-slim@sha256:45cb86ad7b494e381358ae378a04f072f096e11c4e54ed06abdba043fb2667c3
+ARG NIM_IMAGE=nimlang/nim:1.4.4-alpine-slim@sha256:5c82efe7f3afffe4781f3f127d28c21ecb705dc964cc5434fee98feafd63d2d7
 FROM ${NIM_IMAGE} AS builder
 COPY src/runner.nim /build/
 COPY src/unittest_json.nim /build/


### PR DESCRIPTION
This commit updates our `Dockerfile` and CI workflow to use the latest
stable Nim release.

See the [release blog post](https://nim-lang.org/blog/2021/02/23/versions-144-and-1210-released.html).

Note that due to #40, bumping Nim is easier than before - see #39 for
the previous bump from `1.4.0` to `1.4.2`.

--- 

With this PR, searching git-tracked files for `"1\.4"`:
```
.github/workflows/ci.yml
10:  NIM_VERSION: 1.4.4

Dockerfile
1:ARG NIM_IMAGE=nimlang/nim:1.4.4-alpine-slim@sha256:5c82efe7f3afffe4781f3f127d28c21ecb705dc964cc5434fee98feafd63d2d7
```