### PR TITLE
ci: add linting of Dockerfile

### DIFF
--- a/.github/workflows/lint_dockerfile.yml
+++ b/.github/workflows/lint_dockerfile.yml
@@ -1,0 +1,15 @@
+name: Lint Dockerfile
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  hadolint:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # 2.3.4
+
+      - name: Run hadolint
+        uses: brpaz/hadolint-action@1623ba61710b974b55ba455930e6f2c8ef919778 # 1.3.1
+        with:
+          dockerfile: Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
-ARG NIM_IMAGE=nimlang/nim:1.4.4-alpine-slim@sha256:5c82efe7f3afffe4781f3f127d28c21ecb705dc964cc5434fee98feafd63d2d7
-FROM ${NIM_IMAGE} AS builder
+ARG REPO=nimlang/nim
+ARG IMAGE=1.4.4-alpine-slim@sha256:5c82efe7f3afffe4781f3f127d28c21ecb705dc964cc5434fee98feafd63d2d7
+FROM ${REPO}:${IMAGE} AS builder
 COPY src/runner.nim /build/
 COPY src/unittest_json.nim /build/
 RUN nim c -d:release -d:lto -d:strip /build/runner.nim
 
-FROM ${NIM_IMAGE}
+FROM ${REPO}:${IMAGE}
+# We can't reliably pin the `pcre` version here, so we ignore the linter warning.
+# See https://gitlab.alpinelinux.org/alpine/abuild/-/issues/9996
+# hadolint ignore=DL3018
 RUN apk add --no-cache pcre
 WORKDIR /opt/test-runner/
 COPY --from=builder /build/runner bin/


### PR DESCRIPTION
It can be a good idea to lint our Dockerfile. `hadolint` is one such
linter (the name is short for "Haskell Dockerfile Linter") - it
also runs `shellcheck` internally.

Before this commit, running `hadolint` on our Dockerfile would produce:
```
Dockerfile:2 DL3006 warning: Always tag the version of an image explicitly
Dockerfile:7 DL3006 warning: Always tag the version of an image explicitly
Dockerfile:8 DL3018 warning: Pin versions in apk add. Instead of `apk
add <package>` use `apk add <package>=<version>`
```
The first two were false positives, and the third is a real complaint.

Therefore this commit also alters our Dockerfile to workaround the false
positives, and to suppress the warning that is difficult to resolve.

See:
- https://github.com/brpaz/hadolint-action
- https://github.com/hadolint/hadolint

---

Some recent discussion:
- https://news.ycombinator.com/item?id=26446337
- https://pythonspeed.com/articles/security-updates-in-docker/