### PR TITLE
build: use `alpine` directly, not `nimlang/nim`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 *
+!bin/install_nim.sh
 !bin/run.sh
 !src/runner.nim
 !src/unittest_json.nim

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,14 @@
+name: shellcheck
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  shellcheck:
+    name: Run shellcheck on scripts
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # 2.3.4
+
+      - name: Run shellcheck
+        uses: ludeeus/action-shellcheck@94e0aab03ca135d11a35e5bfc14e6746dc56e7e9 # 1.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,40 @@
-ARG REPO=nimlang/nim
-ARG IMAGE=1.4.4-alpine-slim@sha256:5c82efe7f3afffe4781f3f127d28c21ecb705dc964cc5434fee98feafd63d2d7
+ARG REPO=alpine
+ARG IMAGE=3.13.5@sha256:def822f9851ca422481ec6fee59a9966f12b351c62ccb9aca841526ffaa9f748
 FROM ${REPO}:${IMAGE} AS builder
+COPY bin/install_nim.sh /build/
+# We can't reliably pin the versions here, so we ignore the linter warning.
+# See https://gitlab.alpinelinux.org/alpine/abuild/-/issues/9996
+# hadolint ignore=DL3018
+RUN apk add --no-cache --virtual=.build-deps \
+      curl \
+      gcc \
+      musl-dev \
+      tar \
+      xz \
+    && sh /build/install_nim.sh \
+    && apk del .build-deps
+
+FROM ${REPO}:${IMAGE} AS builder2
+# hadolint ignore=DL3018
+RUN apk add --no-cache \
+      gcc \
+      musl-dev
+COPY --from=builder /nim/ /nim/
+RUN ln -s /nim/bin/nim /bin/nim
 COPY src/runner.nim /build/
 COPY src/unittest_json.nim /build/
 RUN nim c -d:release -d:lto -d:strip /build/runner.nim
 
 FROM ${REPO}:${IMAGE}
-# We can't reliably pin the `pcre` version here, so we ignore the linter warning.
-# See https://gitlab.alpinelinux.org/alpine/abuild/-/issues/9996
 # hadolint ignore=DL3018
-RUN apk add --no-cache pcre
+RUN apk add --no-cache \
+      gcc \
+      musl-dev \
+      pcre
+COPY --from=builder /nim/ /nim/
+RUN ln -s /nim/bin/nim /bin/nim
 WORKDIR /opt/test-runner/
-COPY --from=builder /build/runner bin/
+COPY --from=builder2 /build/runner bin/
 COPY bin/run.sh bin/
 COPY src/unittest_json.nim src/
 ENTRYPOINT ["/opt/test-runner/bin/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,33 @@
 ARG REPO=alpine
 ARG IMAGE=3.13.5@sha256:def822f9851ca422481ec6fee59a9966f12b351c62ccb9aca841526ffaa9f748
-FROM ${REPO}:${IMAGE} AS nim_builder
-COPY bin/install_nim.sh /build/
+FROM ${REPO}:${IMAGE} AS base
 # We can't reliably pin the versions here, so we ignore the linter warning.
 # See https://gitlab.alpinelinux.org/alpine/abuild/-/issues/9996
 # hadolint ignore=DL3018
+RUN apk add --no-cache \
+      gcc \
+      musl-dev
+
+FROM base AS nim_builder
+COPY bin/install_nim.sh /build/
+# hadolint ignore=DL3018
 RUN apk add --no-cache --virtual=.build-deps \
       curl \
-      gcc \
-      musl-dev \
       tar \
       xz \
     && sh /build/install_nim.sh \
     && apk del .build-deps
 
-FROM ${REPO}:${IMAGE} AS runner_builder
+FROM base AS runner_builder
 COPY --from=nim_builder /nim/ /nim/
 COPY src/runner.nim /build/
 COPY src/unittest_json.nim /build/
-# hadolint ignore=DL3018
-RUN apk add --no-cache --virtual=.build-deps \
-      gcc \
-      musl-dev \
-    && /nim/bin/nim c -d:release -d:lto -d:strip /build/runner.nim \
-    && apk del .build-deps
+RUN /nim/bin/nim c -d:release -d:lto -d:strip /build/runner.nim
 
-FROM ${REPO}:${IMAGE}
+FROM base
 COPY --from=nim_builder /nim/ /nim/
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
-      gcc \
-      musl-dev \
       pcre \
     && ln -s /nim/bin/nim /usr/local/bin/nim
 WORKDIR /opt/test-runner/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG REPO=alpine
 ARG IMAGE=3.13.5@sha256:def822f9851ca422481ec6fee59a9966f12b351c62ccb9aca841526ffaa9f748
-FROM ${REPO}:${IMAGE} AS builder
+FROM ${REPO}:${IMAGE} AS nim_builder
 COPY bin/install_nim.sh /build/
 # We can't reliably pin the versions here, so we ignore the linter warning.
 # See https://gitlab.alpinelinux.org/alpine/abuild/-/issues/9996
@@ -14,8 +14,8 @@ RUN apk add --no-cache --virtual=.build-deps \
     && sh /build/install_nim.sh \
     && apk del .build-deps
 
-FROM ${REPO}:${IMAGE} AS builder2
-COPY --from=builder /nim/ /nim/
+FROM ${REPO}:${IMAGE} AS runner_builder
+COPY --from=nim_builder /nim/ /nim/
 COPY src/runner.nim /build/
 COPY src/unittest_json.nim /build/
 # hadolint ignore=DL3018
@@ -26,7 +26,7 @@ RUN apk add --no-cache --virtual=.build-deps \
     && apk del .build-deps
 
 FROM ${REPO}:${IMAGE}
-COPY --from=builder /nim/ /nim/
+COPY --from=nim_builder /nim/ /nim/
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
       gcc \
@@ -34,7 +34,7 @@ RUN apk add --no-cache \
       pcre \
     && ln -s /nim/bin/nim /usr/local/bin/nim
 WORKDIR /opt/test-runner/
-COPY --from=builder2 /build/runner bin/
+COPY --from=runner_builder /build/runner bin/
 COPY bin/run.sh bin/
 COPY src/unittest_json.nim src/
 ENTRYPOINT ["/opt/test-runner/bin/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG REPO=alpine
 ARG IMAGE=3.13.5@sha256:def822f9851ca422481ec6fee59a9966f12b351c62ccb9aca841526ffaa9f748
 FROM ${REPO}:${IMAGE} AS base
-# We can't reliably pin the versions here, so we ignore the linter warning.
+# We can't reliably pin the package versions on Alpine, so we ignore the linter warning.
 # See https://gitlab.alpinelinux.org/alpine/abuild/-/issues/9996
 # hadolint ignore=DL3018
 RUN apk add --no-cache \

--- a/bin/install_nim.sh
+++ b/bin/install_nim.sh
@@ -3,7 +3,7 @@
 set -ex
 
 readonly ARCHIVE_FILENAME='nim.tar.xz'
-readonly NIM_VERSION='1.4.6'
+readonly NIM_VERSION='1.4.4'
 readonly BUILD_DIR='/build/nim'
 readonly INSTALL_DIR='/nim/'
 mkdir -p "${BUILD_DIR}"

--- a/bin/install_nim.sh
+++ b/bin/install_nim.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -ex
+
+readonly ARCHIVE_FILENAME='nim.tar.xz'
+readonly NIM_VERSION='1.4.6'
+readonly BUILD_DIR='/build/nim'
+readonly INSTALL_DIR='/nim/'
+mkdir -p "${BUILD_DIR}"
+
+(
+  cd "${BUILD_DIR}" || exit
+  curl -sSfL -o "${ARCHIVE_FILENAME}" "https://nim-lang.org/download/nim-${NIM_VERSION}.tar.xz"
+  tar --strip-components=1 -xf "${ARCHIVE_FILENAME}"
+  sh build.sh
+  rm -r c_code "${ARCHIVE_FILENAME}"
+
+  bin/nim c --skipUserCfg --skipParentCfg koch.nim
+  ./koch boot -d:release -d:leanCompiler
+
+  mkdir -p "${INSTALL_DIR}"
+  mv bin config lib "${INSTALL_DIR}"
+)
+
+rm -r "${BUILD_DIR}"


### PR DESCRIPTION
~I'll tidy up a few more things (e.g. the builder names; symlinking;
maybe use just two build stages instead of three), but I think this PR
is pretty close to complete.~

The resulting Docker image is now smaller than any Nim image I found
in the wild.
I have some ideas to improve it further, but that'll be for a later PR.

The commit message is reproduced below.

---

This commit reduces the size of our Docker image. We were using a
`nimlang/nim` image that is itself based off `alpine:latest`, but we can
just use an `alpine` image directly to avoid some bloat.

```
Before: 249.53 MB
After:  139.68 MB
```

Other advantages:
- Reduced attack surface: we get more control over the image contents -
  we can remove things that we don't need in the test runner
  environment, like `nodejs`.
- We are no longer dependent on `nimlang/nim` for Nim version updates.
- We can update Alpine even if there hasn't been a new Nim version.

Disadvantages:
- `docker build` now takes something like 5 minutes during CI, rather
  than something like 30 seconds.
- Some added complexity.

This commit removes:
- `nodejs`
- The C++ compiler. `nim cpp` is now impossible
- The ability to run `nim doc`
- The ability to run `nim js`
- Some build dependencies: `curl`, `tar`, `xz`
- Unnecessary Nim directories

With this commit, we now build Nim ourselves. We do this by adding a
script, which is better than inlining the commands in the Dockerfile
because we can:
- run and test the script independently.
- run `shellcheck` on it.

This commit also adds a `shellcheck` workflow.