### PR TITLE
build: bump Nim from 1.4.4 to 1.4.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     paths-ignore:
       - '**.md'
 env:
-  NIM_VERSION: 1.4.4
+  NIM_VERSION: 1.4.6
 
 jobs:
   job1:

--- a/bin/install_nim.sh
+++ b/bin/install_nim.sh
@@ -3,7 +3,7 @@
 set -ex
 
 readonly ARCHIVE_FILENAME='nim.tar.xz'
-readonly NIM_VERSION='1.4.4'
+readonly NIM_VERSION='1.4.6'
 readonly BUILD_DIR='/build/nim'
 readonly INSTALL_DIR='/nim/'
 mkdir -p "${BUILD_DIR}"


### PR DESCRIPTION
This commit updates our Docker image and CI workflow to use the latest
stable Nim release.

See the [release blog post](https://nim-lang.org/blog/2021/04/15/versions-146-and-1212-released.html).

---

There are two places to bump it at the moment. With this PR:
```
$ git grep --heading --break '1\.4'
.github/workflows/ci.yml
10:  NIM_VERSION: 1.4.6

.github/workflows/docker.yml
23:        uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # 2.1.4

bin/install_nim.sh
6:readonly NIM_VERSION='1.4.6'
```

It's deliberate that the `bin/install_nim.sh` currently doesn't read from an environment variable. But maybe I should've given the two `NIM_VERSION` different names.
