### PR TITLE
Dockerfile: slim down gcc installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,8 @@ RUN apk add --no-cache \
     && ln -s /nim/bin/nim /usr/local/bin/nim \
     && printf '\nRemoving some unneeded large files:\n' \
     && rm -v /usr/bin/lto-dump \
-    && rm -v /usr/lib/libgphobos.so.1.0.0 \
-    && rm -v /usr/libexec/gcc/x86_64-alpine-linux-musl/10.2.1/lto-wrapper \
-    && rm -v /usr/libexec/gcc/x86_64-alpine-linux-musl/10.2.1/lto1
+    && find / -path '/usr/libexec/gcc/x86_64-alpine-linux-musl/*/lto*' -exec rm -v {} + \
+    && find / -path '/usr/lib/libgphobos.so*' -exec rm -v {} +
 WORKDIR /opt/test-runner/
 COPY --from=runner_builder /build/runner bin/
 COPY bin/run.sh bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,19 @@ COPY src/runner.nim /build/
 COPY src/unittest_json.nim /build/
 RUN /nim/bin/nim c -d:release -d:lto -d:strip /build/runner.nim
 
-FROM base
+FROM ${REPO}:${IMAGE}
 COPY --from=nim_builder /nim/ /nim/
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
+      gcc \
+      musl-dev \
       pcre \
-    && ln -s /nim/bin/nim /usr/local/bin/nim
+    && ln -s /nim/bin/nim /usr/local/bin/nim \
+    && printf '\nRemoving some unneeded large files:\n' \
+    && rm -v /usr/bin/lto-dump \
+    && rm -v /usr/lib/libgphobos.so.1.0.0 \
+    && rm -v /usr/libexec/gcc/x86_64-alpine-linux-musl/10.2.1/lto-wrapper \
+    && rm -v /usr/libexec/gcc/x86_64-alpine-linux-musl/10.2.1/lto1
 WORKDIR /opt/test-runner/
 COPY --from=runner_builder /build/runner bin/
 COPY bin/run.sh bin/


### PR DESCRIPTION
This commit picks the low-hanging fruit for reducing the image size further.

The majority of the image size comes from `gcc`, but we don't need LTO
support or the D standard library in our image, so we can remove a few large
files.

```
Image size before this commit: 139.66 MB
Image size with this commit:    87.46 MB
```

Note that the alpine package manager doesn't support force-removing package dependencies,
and I don't think there's a split package for a more minimal `gcc` install.

---

```
The largest files in the image, before deleting unneeded files:
156.0K	/usr/bin/strip
160.0K	/usr/lib/gcc/x86_64-alpine-linux-musl/10.2.1/plugin/include/gimple.h
164.0K	/usr/libexec/gcc/x86_64-alpine-linux-musl/10.2.1/plugin/gengtype
180.0K	/lib/libapk.so.3.12.0
184.0K	/usr/lib/libitm.a
212.0K	/etc/ssl/certs/ca-certificates.crt
212.0K	/usr/libexec/gcc/x86_64-alpine-linux-musl/10.2.1/install-tools/fixincl
220.0K	/usr/lib/gcc/x86_64-alpine-linux-musl/10.2.1/plugin/include/insn-codes.h
232.0K	/nim/lib/pure/unidecode/unidecode.dat
244.0K	/usr/lib/gcc/x86_64-alpine-linux-musl/10.2.1/plugin/include/tree.h
252.0K	/usr/lib/libgomp.so.1.0.0
304.0K	/usr/lib/gcc/x86_64-alpine-linux-musl/10.2.1/plugin/include/target.def
320.0K	/usr/lib/gcc/x86_64-alpine-linux-musl/10.2.1/plugin/include/cp/cp-tree.h
324.0K	/usr/bin/objdump
364.0K	/usr/lib/libpcre.so.1.2.12
400.0K	/usr/lib/gcc/x86_64-alpine-linux-musl/10.2.1/libgcc_eh.a
400.0K	/usr/lib/gcc/x86_64-alpine-linux-musl/10.2.1/plugin/include/options.h
404.0K	/usr/lib/libgmp.so.10.4.1
420.0K	/usr/lib/gcc/x86_64-alpine-linux-musl/10.2.1/include/avx512vlintrin.h
456.0K	/usr/lib/libgomp.a
472.0K	/usr/bin/gcov-dump
500.0K	/usr/bin/gcov-tool
508.0K	/usr/lib/gcc/x86_64-alpine-linux-musl/10.2.1/include/avx512fintrin.h
512.0K	/lib/libssl.so.1.1
516.0K	/usr/libexec/gcc/x86_64-alpine-linux-musl/10.2.1/collect2
524.0K	/usr/bin/readelf
576.0K	/usr/bin/gcov
592.0K	/lib/ld-musl-x86_64.so.1
604.0K	/usr/bin/as
808.0K	/bin/busybox
952.0K	/usr/lib/gcc/x86_64-alpine-linux-musl/10.2.1/plugin/include/insn-flags.h
976.0K	/usr/libexec/gcc/x86_64-alpine-linux-musl/10.2.1/lto-wrapper
1.1M	/usr/bin/cpp
1.1M	/usr/bin/gcc
1.1M	/usr/lib/libbfd-2.35.2.so
1.1M	/usr/lib/libgdruntime.so.1.0.0
1.2M	/usr/lib/gcc/x86_64-alpine-linux-musl/10.2.1/plugin/gtype.state
1.3M	/usr/lib/libopcodes-2.35.2.so
1.5M	/usr/bin/dwp
1.6M	/usr/bin/ld
1.6M	/usr/lib/libisl.so.22.0.0
1.6M	/usr/lib/libstdc++.so.6.0.28
2.5M	/lib/libcrypto.so.1.1
2.6M	/usr/lib/libmpfr.so.6.1.0
2.9M	/usr/lib/gcc/x86_64-alpine-linux-musl/10.2.1/libgcc.a
4.6M	/nim/bin/nim
5.8M	/usr/lib/libgphobos.so.1.0.0
9.4M	/usr/lib/libc.a
21.5M	/usr/bin/lto-dump
21.5M	/usr/libexec/gcc/x86_64-alpine-linux-musl/10.2.1/lto1
22.4M	/usr/libexec/gcc/x86_64-alpine-linux-musl/10.2.1/cc1

Removing some unneeded large files:
removed '/usr/bin/lto-dump'
removed '/usr/libexec/gcc/x86_64-alpine-linux-musl/10.2.1/lto-wrapper'
removed '/usr/libexec/gcc/x86_64-alpine-linux-musl/10.2.1/lto1'
removed '/usr/lib/libgphobos.so.1'
removed '/usr/lib/libgphobos.so.1.0.0'
removed '/usr/lib/libgphobos.so'

The final contents of the root directory:
87.8M	/
1.1M	/bin
0	/dev
428.0K	/etc
0	/home
3.9M	/lib
0	/media
0	/mnt
9.9M	/nim
0	/opt
0	/proc
0	/root
0	/run
324.0K	/sbin
0	/srv
0	/sys
0	/tmp
72.2M	/usr
12.0K	/var
```