### PR TITLE
build: use `tcc`, not `gcc`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
         sudo mv "nim-${NIM_VERSION}" "${INSTALL_DIR}"
         echo "${INSTALL_DIR}/bin" >> "${GITHUB_PATH}"
 
+    - name: Install tcc
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y tcc
+
     - name: Compile and run `tests/trunner.nim`
       run: "nim c -r --styleCheck:error --hint[Processing]:off tests/trunner.nim"
 
@@ -71,7 +76,7 @@ jobs:
       run: |
         # Create a container from the image we built, overriding the `ENTRYPOINT`
         docker create --rm --entrypoint nim --name ntr "exercism/nim-test-runner:${NIM_VERSION}" \
-          c -r --styleCheck:error --hint[Processing]:off --hint[CC]:off -d:repoSolutions tests/trunner.nim
+          c --cc:tcc -r --styleCheck:error --hint[Processing]:off --hint[CC]:off -d:repoSolutions tests/trunner.nim
         # Copy the required files and run the tests.
         docker cp src/runner.nim ntr:/opt/test-runner/src/
         docker cp tests/ ntr:/opt/test-runner/tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,14 +28,11 @@ FROM ${REPO}:${IMAGE}
 COPY --from=nim_builder /nim/ /nim/
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
-      gcc \
       musl-dev \
       pcre \
-    && ln -s /nim/bin/nim /usr/local/bin/nim \
-    && printf '\nRemoving some unneeded large files:\n' \
-    && rm -v /usr/bin/lto-dump \
-    && find / -path '/usr/libexec/gcc/x86_64-alpine-linux-musl/*/lto*' -exec rm -v {} + \
-    && find / -path '/usr/lib/libgphobos.so*' -exec rm -v {} +
+    && apk add --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/edge/testing \
+      tcc \
+    && ln -s /nim/bin/nim /usr/local/bin/nim
 WORKDIR /opt/test-runner/
 COPY --from=runner_builder /build/runner bin/
 COPY bin/run.sh bin/

--- a/src/runner.nim
+++ b/src/runner.nim
@@ -205,7 +205,7 @@ proc writeOutput*(resultsFileName, runtimeOutput: string) =
 proc run*(paths: Paths): tuple[output: string, exitCode: int] =
   ## Compiles and runs the file in `paths.tmpTest`. Returns its exit code and
   ## the run-time output (which is empty if compilation fails).
-  let (compMsgs, exitCode1) = execCmdEx("nim c --styleCheck:hint " &
+  let (compMsgs, exitCode1) = execCmdEx("nim c --cc:tcc --styleCheck:hint " &
                                         "--skipUserCfg:on --verbosity:0 " &
                                         "--hint[Processing]:off " &
                                         paths.tmpTest)


### PR DESCRIPTION
I'd like to try `tcc` as our C compiler, at least during the beta
period. It has much faster compile times than `gcc`, which should make
things much more responsive for the user.

It's good for non-optimized builds, which is exactly our use case.

Generally it works well, especially for simple programs like Exercism
solutions. But in the long-term, Nim will only fully support GCC, Clang
and MSVC.

We might want to use `tcc` until Nim gains incremental compilation. The
alternative is to add a pre-built `nimcache` into the image and make the
compiler use that when compiling every user's solution. But I want to
try this first.

In the worst case, we can revert this commit before the release of
Exercism v3.

If we stick with `tcc` we probably want to build it from the
maintained branch, rather than using the latest release (which was
a while ago).

Some discussion on the forum:
- https://forum.nim-lang.org/t/6812#42658
- https://forum.nim-lang.org/t/7337#46523

As a bonus, the image is much smaller too:
```
Image size before this commit:  87.48 MB
Image size with this commit:    26.74 MB
```

```
The largest files in the image:
36.0K	/nim/lib/wrappers/openssl.nim
36.0K	/usr/bin/getconf
40.0K	/nim/lib/pure/includes/unicode_ranges.nim
40.0K	/nim/lib/pure/math.nim
40.0K	/nim/lib/pure/parsesql.nim
40.0K	/nim/lib/system/alloc.nim
40.0K	/nim/lib/wrappers/iup.nim
40.0K	/nim/lib/wrappers/linenoise/linenoise.c
44.0K	/nim/lib/pure/httpclient.nim
44.0K	/nim/lib/pure/json.nim
44.0K	/nim/lib/windows/winlean.nim
48.0K	/nim/lib/pure/streams.nim
52.0K	/nim/lib/js/dom.nim
52.0K	/nim/lib/packages/docutils/rstgen.nim
52.0K	/nim/lib/posix/posix_other_consts.nim
52.0K	/nim/lib/wrappers/mysql.nim
52.0K	/usr/bin/getent
56.0K	/nim/lib/posix/posix.nim
56.0K	/nim/lib/pure/osproc.nim
60.0K	/nim/lib/packages/docutils/rst.nim
64.0K	/nim/lib/core/macros.nim
68.0K	/nim/lib/fusion/htmlparser.nim
68.0K	/nim/lib/pure/mimetypes.nim
68.0K	/nim/lib/pure/pegs.nim
72.0K	/nim/lib/pure/htmlparser.nim
72.0K	/sbin/apk
76.0K	/nim/lib/pure/asyncdispatch.nim
76.0K	/nim/lib/pure/net.nim
80.0K	/usr/bin/scanelf
80.0K	/usr/include/elf.h
84.0K	/nim/lib/fusion/btreetables.nim
96.0K	/nim/lib/pure/collections/tables.nim
96.0K	/nim/lib/pure/times.nim
96.0K	/usr/lib/libtls-standalone.so.1.0.0
100.0K	/lib/libz.so.1.2.11
100.0K	/nim/lib/pure/strutils.nim
108.0K	/nim/lib/system.nim
120.0K	/nim/lib/pure/os.nim
180.0K	/lib/libapk.so.3.12.0
184.0K	/usr/bin/tcc
212.0K	/etc/ssl/certs/ca-certificates.crt
232.0K	/nim/lib/pure/unidecode/unidecode.dat
356.0K	/usr/lib/libtcc.a
364.0K	/usr/lib/libpcre.so.1.2.12
512.0K	/lib/libssl.so.1.1
592.0K	/lib/ld-musl-x86_64.so.1
808.0K	/bin/busybox
2.5M	/lib/libcrypto.so.1.1
4.6M	/nim/bin/nim
9.4M	/usr/lib/libc.a

The final contents of the root directory:
28.1M	/
12.5M	/usr
9.9M	/nim
3.9M	/lib
1.1M	/bin
428.0K	/etc
324.0K	/sbin
12.0K	/var
0	/dev
0	/home
0	/media
0	/mnt
0	/opt
0	/proc
0	/root
0	/run
0	/srv
0	/sys
0	/tmp
```