### PR TITLE
Dockerfile: bump Alpine from 3.13.5 to 3.14.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG REPO=alpine
-ARG IMAGE=3.13.5@sha256:def822f9851ca422481ec6fee59a9966f12b351c62ccb9aca841526ffaa9f748
+ARG IMAGE=3.14.0@sha256:1775bebec23e1f3ce486989bfc9ff3c4e951690df84aa9f926497d82f2ffca9d
 FROM ${REPO}:${IMAGE} AS base
 # We can't reliably pin the package versions on Alpine, so we ignore the linter warning.
 # See https://gitlab.alpinelinux.org/alpine/abuild/-/issues/9996


### PR DESCRIPTION
Release notes:
https://alpinelinux.org/posts/Alpine-3.14.0-released.html

---

I'm not sure if dependabot is able to bump this.

It looks like the update was pushed to Docker Hub at `2021-06-15T23:23:??+00:00`, but dependabot didn't bump it with this configuration:

https://github.com/exercism/nim-test-runner/blob/eb9c0a468787f0e57b907125fdcb14d071a5cb7d/.github/dependabot.yml#L10-L15

I'll leave alpine unbumped on the main branch of my fork for a while to see if dependabot opens a PR there.