### PR TITLE
ci(lint_dockerfile): change `hadolint-action` upstream

### DIFF
--- a/.github/workflows/lint_dockerfile.yml
+++ b/.github/workflows/lint_dockerfile.yml
@@ -10,6 +10,6 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # 2.3.4
 
       - name: Run hadolint
-        uses: brpaz/hadolint-action@c27bd9edc1e95eed30474db8f295ff5807ebca14 # 1.5.0
+        uses: hadolint/hadolint-action@c27bd9edc1e95eed30474db8f295ff5807ebca14 # 1.5.0
         with:
           dockerfile: Dockerfile


### PR DESCRIPTION
`hadolint-action` was originally created by brpaz, but has since been
incorporated into the hadolint organization.