### PR TITLE
unittest_json: fix error with devel Nim

### DIFF
--- a/src/unittest_json.nim
+++ b/src/unittest_json.nim
@@ -35,7 +35,7 @@ type
 const
   specVersion = 2
 
-proc newJsonOutputFormatter*(stream: Stream): <//>JsonOutputFormatter =
+proc newJsonOutputFormatter*(stream: Stream): JsonOutputFormatter =
   ## Creates a formatter that writes report to the specified stream in
   ## JSON format.
   ## The ``stream`` is NOT closed automatically when the test are finished,


### PR DESCRIPTION
Before this commit, compiling `unittest_json` with a development version
of Nim (more recent than 2021-04-26) would produce:

```
Error: undeclared identifier: '<//>'
```

This is because `<//>` was removed from Nim upstream. See https://github.com/nim-lang/Nim/commit/68e522ececdb