### PR TITLE
CI: diff json mismatches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
         sudo apt-get update -y
         sudo apt-get install -y tcc
 
+    - name: Install ynfle's fork of the `diff` package pinned to desired the commit
+      run: "nimble install https://github.com/ynfle/diff@#ae470e7702fd07a6ea850b2a6f2de701130fa048 -y"
+
     - name: Compile and run `tests/trunner.nim`
       run: "nim c -r --styleCheck:error --hint[Processing]:off tests/trunner.nim"
 
@@ -72,6 +75,12 @@ jobs:
         # Fail if the output JSON is not as expected.
         diff results.json expected_results.json
 
+    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # 2.4.0
+      with:
+        repository: 'ynfle/diff'
+        ref: 'ae470e7702fd07a6ea850b2a6f2de701130fa048'
+        path: 'diff'
+
     - name: Run tests inside container (including for exercises from `exercism/nim`)
       run: |
         # Create a container from the image we built, overriding the `ENTRYPOINT`
@@ -80,5 +89,6 @@ jobs:
         # Copy the required files and run the tests.
         docker cp src/runner.nim ntr:/opt/test-runner/src/
         docker cp tests/ ntr:/opt/test-runner/tests/
+        docker cp diff/src/diff.nim ntr:/opt/test-runner/tests/diff.nim
         docker cp nim/ ntr:/tmp/exercism-nim/
         docker start -a ntr


### PR DESCRIPTION
This introduces line based diffing showing the diff (Git default styled) between the pretty printed output of the `results.json` & `expected_results.json` using the [`diff`](https://github.com/mark-summerfield/diff) package

Previous method [(link to workflow run)](https://github.com/exercism/nim-test-runner/runs/4375278814?check_suite_focus=true#step:5:279)
<img width="750" alt="Screen Shot 2021-12-01 at 2 45 42 AM" src="https://user-images.githubusercontent.com/23086821/144151252-717d50cb-5ddc-416c-a486-f5d6f2c0fec3.png">

Current Method [(link to line in workflow run)](https://github.com/exercism/nim-test-runner/runs/4375341170?check_suite_focus=true#step:6:289)
<img width="761" alt="Screen Shot 2021-12-01 at 2 51 43 AM" src="https://user-images.githubusercontent.com/23086821/144151719-317b8f9f-f9e4-4899-9937-262f3ba0dde9.png">

There are still the following issue which have to be ironed out:
 - [ ] Installing the `diff` package on the Dockerfile. I currently fails [(see here)](https://github.com/exercism/nim-test-runner/runs/4375341225?check_suite_focus=true#step:6:17)
 - [x] The `diff` package has a style error. See failed run [here](https://github.com/exercism/nim-test-runner/runs/4375281684?check_suite_focus=true#step:6:9). This is why we have the extra commit of changing to `--styleCheck:usages` just to show the diff of adding this diffing functionality (😉 pun intended)
   - MY PR to update the was styling was merged
 