### PR TITLE
Build: use prebuilt alpine version of nim for test-runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 ARG REPO=alpine
 ARG IMAGE=3.14.2@sha256:69704ef328d05a9f806b6b8502915e6a0a4faa4d72018dc42343f511490daf8a
+ARG NIM_REPO=nimlang/nim
+ARG NIM_IMAGE=1.6.0-alpine-regular@sha256:30b04b034c2487fc426ea30d2e698262db5bc5a66668b51f83de15e1b06f9424
 FROM ${REPO}:${IMAGE} AS base
 # We can't reliably pin the package versions on Alpine, so we ignore the linter warning.
 # See https://gitlab.alpinelinux.org/alpine/abuild/-/issues/9996
@@ -8,15 +10,7 @@ RUN apk add --no-cache \
       gcc \
       musl-dev
 
-FROM base AS nim_builder
-COPY bin/install_nim.sh /build/
-# hadolint ignore=DL3018
-RUN apk add --no-cache --virtual=.build-deps \
-      curl \
-      tar \
-      xz \
-    && sh /build/install_nim.sh \
-    && apk del .build-deps
+FROM ${NIM_REPO}:${NIM_IMAGE} AS nim_builder
 
 FROM base AS runner_builder
 COPY --from=nim_builder /nim/ /nim/
@@ -25,7 +19,8 @@ COPY src/unittest_json.nim /build/
 RUN /nim/bin/nim c -d:release -d:lto -d:strip /build/runner.nim
 
 FROM ${REPO}:${IMAGE}
-COPY --from=nim_builder /nim/ /nim/
+COPY --from=nim_builder /nim/bin/nim /nim/bin/nim
+COPY --from=nim_builder /nim/lib/ /nim/lib/
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
       musl-dev \


### PR DESCRIPTION
This uses `nimlang/nim:1.6.0-alpine-regular` to copy over the alpine
version of nim for the test-runner because it is already built and
doesn't have to be rebuilt on every CI test.

There are currently issues with this and I'll hopefully figure them out soon

Related to #116. The advantage of this route, is we don't have to maintain our nim base image (@ee7 is there any advantage to maintaining our own? It didn't seem like you are doing anything special in `bin/install_nim.sh`