### PR TITLE
CI: add concepts exercises to tests

### DIFF
--- a/tests/trunner_repo_solutions.nim
+++ b/tests/trunner_repo_solutions.nim
@@ -5,50 +5,52 @@ proc repoSolutions* =
   let tmpBase = getTempDir()
   let outputDir = tmpBase / "nim_test_runner_out/"
 
-  suite "Run test-runner on the exercises from `exercism/nim`":
-    let baseDir = getTempDir() / "exercism-nim"
-    if not dirExists(baseDir):
-      let cmd = "git clone --depth 1 https://github.com/exercism/nim.git " &
-                baseDir
-      let errC = execCmd(cmd)
-      if errC != 0:
-        echo "Error: failed when running `git clone`"
-        removeDir(baseDir)
-        quit(1)
+  let baseDir = getTempDir() / "exercism-nim"
+  if not dirExists(baseDir):
+    let cmd = "git clone --depth 1 https://github.com/exercism/nim.git " &
+              baseDir
+    let errC = execCmd(cmd)
+    if errC != 0:
+      echo "Error: failed when running `git clone`"
+      removeDir(baseDir)
+      quit(1)
+  for (exercisesKind, solutionFileName) in [("practice", "example.nim"), ("concept", "exemplar.nim")]:
+    suite "Run test-runner on the " & exercisesKind & " exercises from `exercism/nim`":
 
-    var slugs: CritBitTree[void]
+      var slugs: CritBitTree[void]
 
-    let exercisesDir = baseDir / "exercises" / "practice"
-    for (_, dir) in walkDir(exercisesDir):
-      slugs.incl(dir.splitPath().tail)
+      let exercisesDir = baseDir / "exercises" / exercisesKind
+      for (_, dir) in walkDir(exercisesDir):
+        slugs.incl(dir.splitPath().tail)
 
-    # Run the tests in alphabetical order
-    for slug in slugs:
-      test slug:
-        let slugDir = exercisesDir / slug
-        let slugUnder = slug.replace('-', '_')
-        let exampleContents = readFile(slugDir / ".meta" / "example.nim")
-        let solutionPath = slugDir / slugUnder & ".nim"
-        writeFile(solutionPath, exampleContents)
+      # Run the tests in alphabetical order
+      for slug in slugs:
+        test slug:
+          let slugDir = exercisesDir / slug
+          let slugUnder = slug.replace('-', '_')
+          let exampleContents = readFile(slugDir / ".meta" / solutionFileName)
+          let solutionPath = slugDir / slugUnder & ".nim"
+          checkpoint (slugDir / ".meta" / solutionFileName) & $fileExists slugDir / ".meta" / solutionFileName
+          writeFile(solutionPath, exampleContents)
 
-        let conf = Conf(slug: slug,
-                        inputDir: slugDir,
-                        outputDir: outputDir)
+          let conf = Conf(slug: slug,
+                          inputDir: slugDir,
+                          outputDir: outputDir)
 
-        let paths = getPaths(conf)
-        prepareFiles(paths)
-        discard run(paths)
-        let j = parseFile(paths.outResults)
-        for test in j["tests"]:
+          let paths = getPaths(conf)
+          prepareFiles(paths)
+          discard run(paths)
+          let j = parseFile(paths.outResults)
+          for test in j["tests"]:
+            check:
+              test["name"].getStr().len > 0
+              test["output"].getStr().len == 0
+              test["status"].getStr() == "pass"
+              test["test_code"].getStr().len > 0
+              test.len == 4
           check:
-            test["name"].getStr().len > 0
-            test["output"].getStr().len == 0
-            test["status"].getStr() == "pass"
-            test["test_code"].getStr().len > 0
-            test.len == 4
-        check:
-          j["status"].getStr() == "pass"
-        moveFile(paths.outResults, conf.outputDir / slugUnder & ".json")
+            j["status"].getStr() == "pass"
+          moveFile(paths.outResults, conf.outputDir / slugUnder & ".json")
 
 when isMainModule:
   repoSolutions()


### PR DESCRIPTION
The second commit (6ef5d42b93e0bf466e491a96ea5a748ea913538b) is the one that needs to be reviewed. The first commit (eea79e407058f2d33cdffd91bded3144728ff0be) is just there to be able to use the test file that isn't empty that will be added soon (https://github.com/exercism/nim/pull/339). Without this, the CI fails ([see this run](https://github.com/exercism/nim-test-runner/runs/5559905902?check_suite_focus=true)) because the manipulated test file is invalid thus compilation fails.
 - [x] Merge https://github.com/exercism/nim/pull/339
 - [x] Remove eea79e407058f2d33cdffd91bded3144728ff0be

**EDIT**: Updated description