### PR TITLE
github(workflows): remove version comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # 2.4.0
+    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
 
     # Our tests require Nim to be installed to `/nim` because some error messages contain
     # e.g. `/nim/lib/pure/unittest.nim(654)`.
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # 2.4.0
+    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
 
     - name: Download all `exercism/nim` exercises
       run: git clone --depth 1 https://github.com/exercism/nim.git
@@ -75,7 +75,7 @@ jobs:
         # Fail if the output JSON is not as expected.
         diff results.json expected_results.json
 
-    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # 2.4.0
+    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       with:
         repository: 'ynfle/diff'
         ref: 'ae470e7702fd07a6ea850b2a6f2de701130fa048'

--- a/.github/workflows/lint_dockerfile.yml
+++ b/.github/workflows/lint_dockerfile.yml
@@ -7,9 +7,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # 2.4.0
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
 
       - name: Run hadolint
-        uses: hadolint/hadolint-action@d7b38582334d9ac11c12021c16f21d63015fa250 # 1.6.0
+        uses: hadolint/hadolint-action@d7b38582334d9ac11c12021c16f21d63015fa250
         with:
           dockerfile: Dockerfile

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # 2.4.0
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
 
       - name: Run shellcheck
-        uses: ludeeus/action-shellcheck@94e0aab03ca135d11a35e5bfc14e6746dc56e7e9 # 1.1.0
+        uses: ludeeus/action-shellcheck@94e0aab03ca135d11a35e5bfc14e6746dc56e7e9


### PR DESCRIPTION
These comments can be helpful, but dependabot doesn't support them -
they have to be updated manually in dependabot PRs. To remove the burden
of keeping the comments in sync, let's just remove them.

---

With this PR:

```console
$ git grep --break --heading '@' -- .github/workflows
.github/workflows/ci.yml
18:    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
39:      run: "nimble install https://github.com/ynfle/diff@#ae470e7702fd07a6ea850b2a6f2de701130fa048 -y"
49:    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
78:    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579

.github/workflows/deploy.yml
14:    uses: exercism/github-actions/.github/workflows/docker-build-push-image.yml@main

.github/workflows/lint_dockerfile.yml
10:        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
13:        uses: hadolint/hadolint-action@d7b38582334d9ac11c12021c16f21d63015fa250

.github/workflows/shellcheck.yml
11:        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
14:        uses: ludeeus/action-shellcheck@94e0aab03ca135d11a35e5bfc14e6746dc56e7e9

.github/workflows/sync:labels.yml
19:    uses: exercism/github-actions/.github/workflows/labels.yml@main
```