### PR TITLE
ci: bump `hadolint/hadolint-action` from 1.6.0 to 2.1.0

### DIFF
--- a/.github/workflows/lint_dockerfile.yml
+++ b/.github/workflows/lint_dockerfile.yml
@@ -10,6 +10,6 @@ jobs:
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
 
       - name: Run hadolint
-        uses: hadolint/hadolint-action@d7b38582334d9ac11c12021c16f21d63015fa250
+        uses: hadolint/hadolint-action@f988afea3da57ee48710a9795b6bb677cc901183
         with:
           dockerfile: Dockerfile


### PR DESCRIPTION
See:
- https://github.com/hadolint/hadolint-action/releases/tag/v1.7.0
- https://github.com/hadolint/hadolint-action/releases/tag/v2.0.0
- https://github.com/hadolint/hadolint-action/releases/tag/v2.1.0
- https://github.com/hadolint/hadolint-action/compare/d7b38582334d...f988afea3da5

---

Stolen from dependabot on my fork.