### PR TITLE
.github, Dockerfile, tests: bump Nim from 1.6.10 to 2.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     paths-ignore:
       - '**.md'
 env:
-  NIM_VERSION: 1.6.10
+  NIM_VERSION: 2.0.0
 
 jobs:
   job1:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG REPO=alpine
 ARG IMAGE=3.17.0@sha256:c0d488a800e4127c334ad20d61d7bc21b4097540327217dfab52262adc02380c
 ARG NIM_REPO=exercism/nim-docker-base
-ARG NIM_IMAGE=d20bcc5694e0a04ef2db5afe60654e5d323f28da@sha256:b550604c5b3eb1a83250594ab99a1495d3f07820d340f4d17e4c8eb7050b50e5
+ARG NIM_IMAGE=4c2a43210d24c9513348198d0d12d73772a11ab6@sha256:a21e509074bffe364288b2575d0cb07d9627554d981c53ea97b1fb793dfde1bf
 FROM ${REPO}:${IMAGE} AS base
 # We can't reliably pin the package versions on Alpine, so we ignore the linter warning.
 # See https://gitlab.alpinelinux.org/alpine/abuild/-/issues/9996

--- a/tests/error/compiletime_crash_in_solution/expected_results.json
+++ b/tests/error/compiletime_crash_in_solution/expected_results.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
   "status": "error",
-  "message": "\u001B[1m\u001B[0m\u001B[31mError: \u001B[0minternal error: getTypeDescAux(tyEmpty)\u001B[36m\u001B[0m\u001B[0m\n\u001B[31mNo stack traceback available\nTo create a stacktrace, rerun compilation with './koch temp c <file>', see https://nim-lang.github.io/Nim/intern.html#debugging-the-compiler for details\u001B[0m\n",
+  "message": "\u001B[1midentity.nim(3, 12) \u001B[0m\u001B[31mError: \u001B[0mcannot infer element type of items([])\u001B[36m\u001B[0m\u001B[0m\n",
   "tests": []
 }

--- a/tests/error/compiletime_error_empty_solution/expected_results.json
+++ b/tests/error/compiletime_error_empty_solution/expected_results.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
   "status": "error",
-  "message": "\u001B[1mtest_identity.nim(14, 7) \u001B[0mtemplate/generic instantiation of `suite` from here\u001B[0m\n\u001B[1mtest_identity.nim(15, 8) \u001B[0mtemplate/generic instantiation of `test` from here\u001B[0m\n\u001B[1munittest_json.nim(44, 12) \u001B[0mtemplate/generic instantiation of `test` from here\u001B[0m\n\u001B[1mtest_identity.nim(16, 11) \u001B[0m\u001B[31mError: \u001B[0mundeclared identifier: 'identity'\ncandidates (edit distance, scope distance); see '--spellSuggest': \n (0, 5): 'identity' [module declared in test_identity.nim(4, 8)]\u001B[36m\u001B[0m\u001B[0m\n",
+  "message": "\u001B[1mtest_identity.nim(14, 1) \u001B[0mtemplate/generic instantiation of `suite` from here\u001B[0m\n\u001B[1mtest_identity.nim(15, 3) \u001B[0mtemplate/generic instantiation of `test` from here\u001B[0m\n\u001B[1munittest_json.nim(44, 12) \u001B[0mtemplate/generic instantiation of `test` from here\u001B[0m\n\u001B[1mtest_identity.nim(16, 11) \u001B[0m\u001B[31mError: \u001B[0mundeclared identifier: 'identity'\ncandidates (edit distance, scope distance); see '--spellSuggest': \n (0, 5): 'identity'\u001B[36m\u001B[0m\u001B[0m\n",
   "tests": []
 }

--- a/tests/error/compiletime_error_type_mismatch_in_test/expected_results.json
+++ b/tests/error/compiletime_error_type_mismatch_in_test/expected_results.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
   "status": "error",
-  "message": "\u001B[1mtest_identity.nim(14, 7) \u001B[0mtemplate/generic instantiation of `suite` from here\u001B[0m\n\u001B[1mtest_identity.nim(15, 8) \u001B[0mtemplate/generic instantiation of `test` from here\u001B[0m\n\u001B[1munittest_json.nim(44, 12) \u001B[0mtemplate/generic instantiation of `test` from here\u001B[0m\n\u001B[1mtest_identity.nim(16, 11) \u001B[0mtemplate/generic instantiation of `check` from here\u001B[0m\n\u001B[1m/nim/lib/pure/unittest.nim(681, 43) \u001B[0m\u001B[31mError: \u001B[0mtype mismatch: got <int literal(1)>\nbut expected one of:\nfunc identity(s: string): string\n  first type mismatch at position: 1\n  required type for s: string\n  but expression '1' is of type: int literal(1)\n\nexpression: identity(1)\u001B[36m\u001B[0m\u001B[0m\n",
+  "message": "\u001B[1mtest_identity.nim(14, 1) \u001B[0mtemplate/generic instantiation of `suite` from here\u001B[0m\n\u001B[1mtest_identity.nim(15, 3) \u001B[0mtemplate/generic instantiation of `test` from here\u001B[0m\n\u001B[1munittest_json.nim(44, 12) \u001B[0mtemplate/generic instantiation of `test` from here\u001B[0m\n\u001B[1mtest_identity.nim(16, 5) \u001B[0mtemplate/generic instantiation of `check` from here\u001B[0m\n\u001B[1m/nim/lib/pure/unittest.nim(692, 43) \u001B[0m\u001B[31mError: \u001B[0mtype mismatch\nExpression: identity(1)\n  [1] 1: int literal(1)\n\nExpected one of (first mismatch at [position]):\n[1] func identity(s: string): string\n\u001B[36m\u001B[0m\u001B[0m\n",
   "tests": []
 }

--- a/tests/error/compiletime_error_undeclared_variable_in_solution/expected_results.json
+++ b/tests/error/compiletime_error_undeclared_variable_in_solution/expected_results.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
   "status": "error",
-  "message": "\u001B[1midentity.nim(2, 3) \u001B[0m\u001B[31mError: \u001B[0mundeclared identifier: 'myUndeclaredVariable'\ncandidates (edit distance, scope distance); see '--spellSuggest': \n (11, 4): 'declaredInScope' [proc declared in /nim/lib/system.nim(187, 8)]\u001B[36m\u001B[0m\u001B[0m\n",
+  "message": "\u001B[1midentity.nim(2, 3) \u001B[0m\u001B[31mError: \u001B[0mundeclared identifier: 'myUndeclaredVariable'\ncandidates (edit distance, scope distance); see '--spellSuggest': \n (11, 4): 'declaredInScope'\u001B[36m\u001B[0m\u001B[0m\n",
   "tests": []
 }

--- a/tests/error/runtime_exception_in_solution/expected_results.json
+++ b/tests/error/runtime_exception_in_solution/expected_results.json
@@ -5,7 +5,7 @@
     {
       "name": "identity function of 1",
       "status": "error",
-      "message": "Unhandled exception: myValueError [ValueError]\n/nim/lib/pure/unittest.nim(681) test_identity\nidentity.nim(2) identity\n",
+      "message": "Unhandled exception: myValueError [ValueError]\n/nim/lib/pure/unittest.nim(692) test_identity\nidentity.nim(2) identity\n",
       "output": "",
       "test_code": "check identity(1) == 1"
     }


### PR DESCRIPTION
See the Nim 2.0 [blog post][1] and [changelog][2].

[1]: https://nim-lang.org/blog/2023/08/01/nim-v20-released.html
[2]: https://github.com/nim-lang/Nim/blob/a488067a4130f029000be4550a0fb1b39e0e9e7c/changelogs/changelog_2_0_0_details.md

Refs: #139
Closes: #154

---

To-do:
- [x] Either set `--threads:off`, or pass `--tlsEmulation:on`, or move away from tcc
- [x] Update error messages

Previous bump: https://github.com/exercism/nim-test-runner/pull/143
Upstream: https://github.com/exercism/nim-docker-base/commit/4c2a43210d24c9513348198d0d12d73772a11ab6
Base image: https://hub.docker.com/layers/exercism/nim-docker-base/4c2a43210d24c9513348198d0d12d73772a11ab6/images/sha256-a21e509074bffe364288b2575d0cb07d9627554d981c53ea97b1fb793dfde1bf