### PR TITLE
.github, Dockerfile, runner: explicitly disable threads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       run: "nimble install https://github.com/ynfle/diff@#ae470e7702fd07a6ea850b2a6f2de701130fa048 -y"
 
     - name: Compile and run `tests/trunner.nim`
-      run: "nim c -r --styleCheck:error --hint[Processing]:off tests/trunner.nim"
+      run: "nim c -r --threads:off --styleCheck:error --hint[Processing]:off tests/trunner.nim"
 
   job2:
     name: Docker - build image and run
@@ -85,7 +85,7 @@ jobs:
       run: |
         # Create a container from the image we built, overriding the `ENTRYPOINT`
         docker create --rm --entrypoint nim --name ntr "exercism/nim-test-runner:${NIM_VERSION}" \
-          c --cc:tcc -r --styleCheck:error --hint[Processing]:off --hint[CC]:off -d:repoSolutions tests/trunner.nim
+          c --cc:tcc --threads:off -r --styleCheck:error --hint[Processing]:off --hint[CC]:off -d:repoSolutions tests/trunner.nim
         # Copy the required files and run the tests.
         docker cp src/runner.nim ntr:/opt/test-runner/src/
         docker cp tests/ ntr:/opt/test-runner/tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM base AS runner_builder
 COPY --from=nim_builder /nim/ /nim/
 COPY src/runner.nim /build/
 COPY src/unittest_json.nim /build/
-RUN /nim/bin/nim c -d:release -d:lto -d:strip /build/runner.nim
+RUN /nim/bin/nim c --threads:off -d:release -d:lto -d:strip /build/runner.nim
 
 FROM ${REPO}:${IMAGE}
 COPY --from=nim_builder /nim/ /nim/

--- a/src/runner.nim
+++ b/src/runner.nim
@@ -209,7 +209,7 @@ proc writeOutput*(resultsFileName, runtimeOutput: string) =
 proc run*(paths: Paths): tuple[output: string, exitCode: int] =
   ## Compiles and runs the file in `paths.tmpTest`. Returns its exit code and
   ## the run-time output (which is empty if compilation fails).
-  let (compMsgs, exitCode1) = execCmdEx("nim c --cc:tcc --styleCheck:hint " &
+  let (compMsgs, exitCode1) = execCmdEx("nim c --cc:tcc --threads:off --styleCheck:hint " &
                                         "--skipUserCfg:on --verbosity:0 " &
                                         "--hint[Processing]:off --colors: on " &
                                         paths.tmpTest)


### PR DESCRIPTION
Nim 2.0 will enable threads by default. Let's handle the enabling of threads independently from the Nim bump.

To enable threads, we'd need to:

- add a test for threads
- and either:
  - add `--tlsEmulation:on` to allow compiling with tcc, and probably update tcc too
  - stop using tcc

Refs: #93

---

See failing [CI log](https://github.com/exercism/nim-test-runner/actions/runs/5736925318/job/15547527748) from the Nim 2.0 bump PR.