### PR TITLE
.github: run ci workflow on workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+  workflow_dispatch:
 env:
   NIM_VERSION: 2.0.0
 


### PR DESCRIPTION
Whilst investigating https://forum.exercism.org/t/nim-test-runner-bug-after-exercism-submit/10088/5, I found that we don't yet allow for running the CI workflow manually. This PR adds support for that.