### PR TITLE
.dockerignore: ignore tests directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,3 @@
 !bin/run.sh
 !src/runner.nim
 !src/unittest_json.nim
-!tests/


### PR DESCRIPTION
I think the `tests` directory can be ignore as the Dockerfile doesn't seem to depend on it and CI [copies the tests files into the container](https://github.com/exercism/nim-test-runner/blob/main/.github/workflows/ci.yml#L91).