### PR TITLE
Dockerfile: install tcc-libs-static

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ RUN apk add --no-cache \
       pcre \
     && apk add --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/edge/testing \
       tcc \
-      tcc-libs \
       tcc-libs-static \
     && ln -s /nim/bin/nim /usr/local/bin/nim
 WORKDIR /opt/test-runner/


### PR DESCRIPTION
Despite no change to the `Dockerfile` on our end, we were seeing an error:

```text
tcc: error: libtcc1.a not found
```

This was due to Alpine [splitting the tcc package][1] into:

- `tcc`
- `tcc-dev`
- `tcc-doc`
- `tcc-libs`
- `tcc-libs-static`

combined with the other underlying problems:

- The `tcc` package in Alpine is in the `testing` repo, which makes breaking changes more likely
- The CI workflow was skipped in a PR that changed only docs, but would have failed if it ran
- The deployment workflow runs on `main` even if the CI workflow fails on `main`
- The `tcc` package isn't pinned, because we [can't reliably pin package versions on Alpine][2]:

https://github.com/exercism/nim-test-runner/blob/05911af09ac2ba8708304998aadfb92ec7976416/Dockerfile#L6-L11

https://github.com/exercism/nim-test-runner/blob/05911af09ac2ba8708304998aadfb92ec7976416/Dockerfile#L23-L28

Install the new `tcc-libs-static` subpackage so that `libtcc1.a` is available again. See the contents of the tcc packages:

- [tcc](https://pkgs.alpinelinux.org/contents?branch=edge&name=tcc&arch=x86_64&repo=testing)
- [tcc-dev](https://pkgs.alpinelinux.org/contents?branch=edge&name=tcc%2ddev&arch=x86_64&repo=testing)
- [tcc-doc](https://pkgs.alpinelinux.org/contents?branch=edge&name=tcc%2ddoc&arch=x86_64&repo=testing)
- [tcc-libs](https://pkgs.alpinelinux.org/contents?branch=edge&name=tcc%2dlibs&arch=x86_64&repo=testing)
- [tcc-libs-static](https://pkgs.alpinelinux.org/contents?branch=edge&name=tcc%2dlibs%2dstatic&arch=x86_64&repo=testing)

This commit also bumps the tcc version, because the current state (bcb20108c76d) was deployed [after the upstream bump][4].

Fixes: https://github.com/exercism/nim-test-runner/issues/165
Fixes: https://github.com/exercism/nim-test-runner/issues/166

[1]: https://git.alpinelinux.org/aports/commit/?id=e2fff91d821a89e4ce5a205207181ed9fdb18c16
[2]: https://gitlab.alpinelinux.org/alpine/abuild/-/issues/9996
[4]: https://git.alpinelinux.org/aports/commit/testing?id=d697e994f093e65208d05a83bf2a0a9750002d20