### PR TITLE
.github, Dockerfile: bump Nim from 2.0.0 to 2.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   workflow_dispatch:
 env:
-  NIM_VERSION: 2.0.0
+  NIM_VERSION: 2.0.2
 
 jobs:
   job1:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG REPO=alpine
 ARG IMAGE=3.19.1@sha256:6457d53fb065d6f250e1504b9bc42d5b6c65941d57532c072d929dd0628977d0
 ARG NIM_REPO=exercism/nim-docker-base
-ARG NIM_IMAGE=b71c422a03821f4764cf5a38d5b1d43f2e4022e5@sha256:f0f00a1be7e9de17bfcc5a0e9545b61a62e5b3b60687d8f17b72be41357c11fd
+ARG NIM_IMAGE=68a971c28c2f5bd44915c1bd24cfd2a5856e5704@sha256:bc998636985028f4d0770f5aaed81cde64ffb429c43e90a36d2e7db54cd259c8
 FROM ${REPO}:${IMAGE} AS base
 # We can't reliably pin the package versions on Alpine, so we ignore the linter warning.
 # See https://gitlab.alpinelinux.org/alpine/abuild/-/issues/9996


### PR DESCRIPTION
See the [release post][1] and [changes][2].

[1]: https://nim-lang.org/blog/2023/12/19/versions-1618-202-released.html
[2]: https://github.com/nim-lang/Nim/compare/v2.0.0...v2.0.2

---

Previous bump: https://github.com/exercism/nim-test-runner/commit/7fba1475e04016f91e5a134e5276e09a0f7cb0ff

Upstream:
- https://github.com/exercism/nim-docker-base/commit/68a971c28c2f5bd44915c1bd24cfd2a5856e5704
- https://hub.docker.com/layers/exercism/nim-docker-base/68a971c28c2f5bd44915c1bd24cfd2a5856e5704/images/sha256-bc998636985028f4d0770f5aaed81cde64ffb429c43e90a36d2e7db54cd259c8?context=explore