### PR TITLE
.github: bump ubuntu-20.04 to ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   job1:
     name: trunner.nim
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
@@ -40,7 +40,7 @@ jobs:
 
   job2:
     name: Docker - build image and run
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608

--- a/.github/workflows/lint_dockerfile.yml
+++ b/.github/workflows/lint_dockerfile.yml
@@ -3,7 +3,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   hadolint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -5,7 +5,7 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   shellcheck:
     name: Run shellcheck on scripts
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608


### PR DESCRIPTION
With this PR, all ubuntu labels are `ubuntu-22.04`:

```console
$ git grep --break --heading ubuntu
.github/workflows/ci.yml
12:    runs-on: ubuntu-22.04
43:    runs-on: ubuntu-22.04

.github/workflows/lint_dockerfile.yml
6:    runs-on: ubuntu-22.04

.github/workflows/shellcheck.yml
8:    runs-on: ubuntu-22.04
```