### PR TITLE
Bump the base image from Alpine 3.22 to 3.24.1 (latest)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-ARG REPO=alpine
-ARG IMAGE=3.22@sha256:8a1f59ffb675680d47db6337b49d22281a139e9d709335b492be023728e11715
 ARG NIM_REPO=exercism/nim-docker-base
 ARG NIM_IMAGE=56de50f73092295436b31dcb45f081436159755f@sha256:240c8b22824c8b8a21541186e46f6eebe5ee2a774f89b35e48c2578ec92899fa
-FROM ${REPO}:${IMAGE} AS base
+# target = alpine:latest
+FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS base
 # We can't reliably pin the package versions on Alpine, so we ignore the linter warning.
 # See https://gitlab.alpinelinux.org/alpine/abuild/-/issues/9996
 # hadolint ignore=DL3018
@@ -18,7 +17,8 @@ COPY src/runner.nim /build/
 COPY src/unittest_json.nim /build/
 RUN /nim/bin/nim c --threads:off -d:release -d:lto -d:strip /build/runner.nim
 
-FROM ${REPO}:${IMAGE}
+# target = alpine:latest
+FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 COPY --from=nim_builder /nim/ /nim/
 # hadolint ignore=DL3018
 RUN apk add --no-cache \


### PR DESCRIPTION
This should pull the nim version from nim-docker-base once it gets updated
